### PR TITLE
Reference Datatype Serialization

### DIFF
--- a/docs/classes/expression_comparison.comparison.html
+++ b/docs/classes/expression_comparison.comparison.html
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L57">expression/comparison/index.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L57">expression/comparison/index.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -328,7 +328,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +356,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_eq.equal.html
+++ b/docs/classes/expression_comparison_eq.equal.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/eq.ts#L15">expression/comparison/eq.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/eq.ts#L15">expression/comparison/eq.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/eq.ts#L32">expression/comparison/eq.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/eq.ts#L32">expression/comparison/eq.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_ge.greaterthanorequal.html
+++ b/docs/classes/expression_comparison_ge.greaterthanorequal.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ge.ts#L16">expression/comparison/ge.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ge.ts#L16">expression/comparison/ge.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ge.ts#L33">expression/comparison/ge.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ge.ts#L33">expression/comparison/ge.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_gt.greaterthan.html
+++ b/docs/classes/expression_comparison_gt.greaterthan.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/gt.ts#L16">expression/comparison/gt.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/gt.ts#L16">expression/comparison/gt.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/gt.ts#L33">expression/comparison/gt.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/gt.ts#L33">expression/comparison/gt.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_in.in.html
+++ b/docs/classes/expression_comparison_in.in.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/in.ts#L15">expression/comparison/in.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/in.ts#L15">expression/comparison/in.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/in.ts#L32">expression/comparison/in.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/in.ts#L32">expression/comparison/in.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/in.ts#L62">expression/comparison/in.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/in.ts#L62">expression/comparison/in.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_le.lessthanorequal.html
+++ b/docs/classes/expression_comparison_le.lessthanorequal.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/le.ts#L16">expression/comparison/le.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/le.ts#L16">expression/comparison/le.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/le.ts#L33">expression/comparison/le.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/le.ts#L33">expression/comparison/le.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_lt.lessthan.html
+++ b/docs/classes/expression_comparison_lt.lessthan.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/lt.ts#L16">expression/comparison/lt.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/lt.ts#L16">expression/comparison/lt.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/lt.ts#L33">expression/comparison/lt.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/lt.ts#L33">expression/comparison/lt.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_ne.notequal.html
+++ b/docs/classes/expression_comparison_ne.notequal.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ne.ts#L15">expression/comparison/ne.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ne.ts#L15">expression/comparison/ne.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ne.ts#L32">expression/comparison/ne.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ne.ts#L32">expression/comparison/ne.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L47">expression/comparison/index.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_not_in.notin.html
+++ b/docs/classes/expression_comparison_not_in.notin.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/not-in.ts#L15">expression/comparison/not-in.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/not-in.ts#L15">expression/comparison/not-in.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/not-in.ts#L32">expression/comparison/not-in.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/not-in.ts#L32">expression/comparison/not-in.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/not-in.ts#L64">expression/comparison/not-in.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/not-in.ts#L64">expression/comparison/not-in.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_overlap.overlap.html
+++ b/docs/classes/expression_comparison_overlap.overlap.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/overlap.ts#L15">expression/comparison/overlap.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/overlap.ts#L15">expression/comparison/overlap.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/overlap.ts#L32">expression/comparison/overlap.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/overlap.ts#L32">expression/comparison/overlap.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/overlap.ts#L55">expression/comparison/overlap.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/overlap.ts#L55">expression/comparison/overlap.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_prefix.prefix.html
+++ b/docs/classes/expression_comparison_prefix.prefix.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/prefix.ts#L16">expression/comparison/prefix.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/prefix.ts#L16">expression/comparison/prefix.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/prefix.ts#L33">expression/comparison/prefix.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/prefix.ts#L33">expression/comparison/prefix.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/prefix.ts#L44">expression/comparison/prefix.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/prefix.ts#L44">expression/comparison/prefix.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_present.present.html
+++ b/docs/classes/expression_comparison_present.present.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/present.ts#L18">expression/comparison/present.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/present.ts#L18">expression/comparison/present.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/present.ts#L36">expression/comparison/present.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/present.ts#L36">expression/comparison/present.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/present.ts#L48">expression/comparison/present.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/present.ts#L48">expression/comparison/present.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -289,7 +289,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -318,7 +318,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/present.ts#L44">expression/comparison/present.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/present.ts#L44">expression/comparison/present.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_suffix.suffix.html
+++ b/docs/classes/expression_comparison_suffix.suffix.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/suffix.ts#L16">expression/comparison/suffix.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/suffix.ts#L16">expression/comparison/suffix.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/suffix.ts#L33">expression/comparison/suffix.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/suffix.ts#L33">expression/comparison/suffix.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L74">expression/comparison/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/suffix.ts#L44">expression/comparison/suffix.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/suffix.ts#L44">expression/comparison/suffix.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_comparison_undefined.undefined.html
+++ b/docs/classes/expression_comparison_undefined.undefined.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/undefined.ts#L18">expression/comparison/undefined.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/undefined.ts#L18">expression/comparison/undefined.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L21">expression/comparison/index.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#comparison">comparison</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/undefined.ts#L36">expression/comparison/undefined.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/undefined.ts#L36">expression/comparison/undefined.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L39">expression/comparison/index.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/undefined.ts#L51">expression/comparison/undefined.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/undefined.ts#L51">expression/comparison/undefined.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -294,7 +294,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/index.ts#L62">expression/comparison/index.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -323,7 +323,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_comparison.comparison.html">Comparison</a>.<a href="expression_comparison.comparison.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/undefined.ts#L44">expression/comparison/undefined.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/undefined.ts#L44">expression/comparison/undefined.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical.logical.html
+++ b/docs/classes/expression_logical.logical.html
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -205,7 +205,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L35">expression/logical/index.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L35">expression/logical/index.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -252,7 +252,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L40">expression/logical/index.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L40">expression/logical/index.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical_and.and.html
+++ b/docs/classes/expression_logical_and.and.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/and.ts#L16">expression/logical/and.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/and.ts#L16">expression/logical/and.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/and.ts#L33">expression/logical/and.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/and.ts#L33">expression/logical/and.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -253,7 +253,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/and.ts#L45">expression/logical/and.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/and.ts#L45">expression/logical/and.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical_nor.nor.html
+++ b/docs/classes/expression_logical_nor.nor.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/nor.ts#L17">expression/logical/nor.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/nor.ts#L17">expression/logical/nor.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/nor.ts#L34">expression/logical/nor.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/nor.ts#L34">expression/logical/nor.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -253,7 +253,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/nor.ts#L46">expression/logical/nor.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/nor.ts#L46">expression/logical/nor.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical_not.not.html
+++ b/docs/classes/expression_logical_not.not.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/not.ts#L16">expression/logical/not.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/not.ts#L16">expression/logical/not.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -179,7 +179,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/not.ts#L34">expression/logical/not.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/not.ts#L34">expression/logical/not.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -250,7 +250,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/not.ts#L48">expression/logical/not.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/not.ts#L48">expression/logical/not.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical_or.or.html
+++ b/docs/classes/expression_logical_or.or.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/or.ts#L16">expression/logical/or.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/or.ts#L16">expression/logical/or.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/or.ts#L33">expression/logical/or.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/or.ts#L33">expression/logical/or.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -253,7 +253,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/or.ts#L45">expression/logical/or.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/or.ts#L45">expression/logical/or.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/expression_logical_xor.xor.html
+++ b/docs/classes/expression_logical_xor.xor.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/xor.ts#L28">expression/logical/xor.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/xor.ts#L28">expression/logical/xor.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L19">expression/logical/index.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/xor.ts#L45">expression/logical/xor.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/xor.ts#L45">expression/logical/xor.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L56">expression/logical/index.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -253,7 +253,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/xor.ts#L60">expression/logical/xor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/xor.ts#L60">expression/logical/xor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="expression_logical.logical.html">Logical</a>.<a href="expression_logical.logical.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/index.ts#L46">expression/logical/index.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/index.default.html
+++ b/docs/classes/index.default.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L54">index.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L54">index.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">parser<span class="tsd-signature-symbol">:</span> <a href="parser.parser-1.html" class="tsd-signature-type" data-tsd-kind="Class">Parser</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L54">index.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L54">index.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L70">index.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L70">index.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L88">index.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L88">index.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L105">index.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L105">index.ts:105</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L79">index.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L79">index.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/operand.operand-1.html
+++ b/docs/classes/operand.operand-1.html
@@ -154,7 +154,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L14">operand/index.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L14">operand/index.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L19">operand/index.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L19">operand/index.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L29">operand/index.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L29">operand/index.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L24">operand/index.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L24">operand/index.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/common_evaluable.evaluable.html">Evaluable</a>.<a href="../interfaces/common_evaluable.evaluable.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L34">operand/index.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L34">operand/index.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/operand_collection.collection.html
+++ b/docs/classes/operand_collection.collection.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L18">operand/collection.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L18">operand/collection.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><a href="operand_value.value.html" class="tsd-signature-type" data-tsd-kind="Class">Value</a><span class="tsd-signature-symbol"> | </span><a href="operand_reference.reference.html" class="tsd-signature-type" data-tsd-kind="Class">Reference</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L18">operand/collection.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L18">operand/collection.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L14">operand/index.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L14">operand/index.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L34">operand/collection.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L34">operand/collection.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L56">operand/collection.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L56">operand/collection.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L41">operand/collection.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L41">operand/collection.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -271,7 +271,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/collection.ts#L66">operand/collection.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/collection.ts#L66">operand/collection.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/operand_reference.reference.html
+++ b/docs/classes/operand_reference.reference.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L105">operand/reference.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L105">operand/reference.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../enums/operand_reference.datatype.html#number" class="tsd-signature-type" data-tsd-kind="Enumeration member">Number</a><span class="tsd-signature-symbol"> | </span><a href="../enums/operand_reference.datatype.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">String</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L105">operand/reference.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L105">operand/reference.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L104">operand/reference.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L104">operand/reference.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L14">operand/index.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L14">operand/index.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L133">operand/reference.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L133">operand/reference.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L157">operand/reference.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L157">operand/reference.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L140">operand/reference.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L140">operand/reference.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L174">operand/reference.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L175">operand/reference.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -318,7 +318,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L165">operand/reference.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L166">operand/reference.ts:166</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/operand_value.value.html
+++ b/docs/classes/operand_value.value.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L27">operand/value.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L27">operand/value.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/index.ts#L14">operand/index.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/index.ts#L14">operand/index.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../modules/common_evaluable.html#result" class="tsd-signature-type" data-tsd-kind="Type alias">Result</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L27">operand/value.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L27">operand/value.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#evaluate">evaluate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L46">operand/value.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L46">operand/value.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L60">operand/value.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L60">operand/value.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#simplify">simplify</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L53">operand/value.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L53">operand/value.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="operand.operand-1.html">Operand</a>.<a href="operand.operand-1.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/value.ts#L68">operand/value.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/value.ts#L68">operand/value.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/parser.parser-1.html
+++ b/docs/classes/parser.parser-1.html
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L74">parser/index.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L74">parser/index.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">expected<wbr>Operators<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L74">parser/index.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L74">parser/index.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">opts<span class="tsd-signature-symbol">:</span> <a href="../interfaces/parser_options.options.html" class="tsd-signature-type" data-tsd-kind="Interface">Options</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L73">parser/index.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L73">parser/index.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L98">parser/index.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L98">parser/index.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L255">parser/index.ts:255</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L255">parser/index.ts:255</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L107">parser/index.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L107">parser/index.ts:107</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L126">parser/index.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L126">parser/index.ts:126</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/enums/common_evaluable.evaluabletype.html
+++ b/docs/enums/common_evaluable.evaluabletype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Expression<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Expression&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L43">common/evaluable.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L43">common/evaluable.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Operand<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Operand&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L42">common/evaluable.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L42">common/evaluable.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operand_reference.datatype.html
+++ b/docs/enums/operand_reference.datatype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L91">operand/reference.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L91">operand/reference.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;String&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/operand/reference.ts#L92">operand/reference.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/operand/reference.ts#L92">operand/reference.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/common_evaluable.evaluable.html
+++ b/docs/interfaces/common_evaluable.evaluable.html
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/common_evaluable.evaluabletype.html" class="tsd-signature-type" data-tsd-kind="Enumeration">EvaluableType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L50">common/evaluable.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L50">common/evaluable.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L57">common/evaluable.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L57">common/evaluable.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L73">common/evaluable.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L73">common/evaluable.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L66">common/evaluable.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L66">common/evaluable.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L78">common/evaluable.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L78">common/evaluable.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/parser_options.options.html
+++ b/docs/interfaces/parser_options.options.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">operator<wbr>Mapping<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L70">parser/options.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L70">parser/options.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">reference<wbr>Predicate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>operand<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L41">parser/options.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L41">parser/options.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,13 +167,13 @@
 					<div class="tsd-signature tsd-kind-icon">reference<wbr>Serialization<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>operand<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L64">parser/options.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L64">parser/options.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>A function used to tranform ths stripped form of a reference into an
-								annoteted version of the reference. This function should be the inverse
+							<p>A function used to transform the stripped form of a reference into an
+								annotated version of the reference. This function should be the inverse
 							function of referenceTranform.</p>
 						</div>
 						<p>referenceSerialization(referenceTransform(&quot;$Reference&quot;)) === &#39;$Reference&#39;</p>
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">reference<wbr>Transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>operand<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L51">parser/options.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L51">parser/options.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/common_evaluable.html
+++ b/docs/modules/common_evaluable.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><a href="common_evaluable.html#result" class="tsd-signature-type" data-tsd-kind="Type alias">Result</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/evaluable.ts#L33">common/evaluable.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/evaluable.ts#L33">common/evaluable.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/common_type_check.html
+++ b/docs/modules/common_type_check.html
@@ -94,7 +94,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/type-check.ts#L43">common/type-check.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/type-check.ts#L43">common/type-check.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/type-check.ts#L52">common/type-check.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/type-check.ts#L52">common/type-check.ts:52</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/type-check.ts#L12">common/type-check.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/type-check.ts#L12">common/type-check.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/type-check.ts#L28">common/type-check.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/type-check.ts#L28">common/type-check.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/type-check.ts#L20">common/type-check.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/type-check.ts#L20">common/type-check.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/common_util.html
+++ b/docs/modules/common_util.html
@@ -91,7 +91,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/util.ts#L8">common/util.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/util.ts#L8">common/util.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/common/util.ts#L26">common/util.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/common/util.ts#L26">common/util.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/expression_comparison_eq.html
+++ b/docs/modules/expression_comparison_eq.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_eq.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/eq.ts#L10">expression/comparison/eq.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L30">index.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/eq.ts#L10">expression/comparison/eq.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L30">index.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_ge.html
+++ b/docs/modules/expression_comparison_ge.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_ge.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ge.ts#L11">expression/comparison/ge.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L33">index.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ge.ts#L11">expression/comparison/ge.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L33">index.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_gt.html
+++ b/docs/modules/expression_comparison_gt.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_gt.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/gt.ts#L11">expression/comparison/gt.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L32">index.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/gt.ts#L11">expression/comparison/gt.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L32">index.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_in.html
+++ b/docs/modules/expression_comparison_in.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_in.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/in.ts#L10">expression/comparison/in.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L36">index.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/in.ts#L10">expression/comparison/in.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L36">index.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_le.html
+++ b/docs/modules/expression_comparison_le.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_le.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/le.ts#L11">expression/comparison/le.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L35">index.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/le.ts#L11">expression/comparison/le.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L35">index.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_lt.html
+++ b/docs/modules/expression_comparison_lt.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_lt.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/lt.ts#L11">expression/comparison/lt.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L34">index.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/lt.ts#L11">expression/comparison/lt.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L34">index.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_ne.html
+++ b/docs/modules/expression_comparison_ne.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_ne.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/ne.ts#L10">expression/comparison/ne.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L31">index.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/ne.ts#L10">expression/comparison/ne.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L31">index.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_not_in.html
+++ b/docs/modules/expression_comparison_not_in.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_not_in.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/not-in.ts#L10">expression/comparison/not-in.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L37">index.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/not-in.ts#L10">expression/comparison/not-in.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L37">index.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_overlap.html
+++ b/docs/modules/expression_comparison_overlap.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_overlap.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/overlap.ts#L10">expression/comparison/overlap.ts:10</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L40">index.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/overlap.ts#L10">expression/comparison/overlap.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L40">index.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_prefix.html
+++ b/docs/modules/expression_comparison_prefix.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_prefix.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/prefix.ts#L11">expression/comparison/prefix.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L38">index.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/prefix.ts#L11">expression/comparison/prefix.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L38">index.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_present.html
+++ b/docs/modules/expression_comparison_present.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_present.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/present.ts#L13">expression/comparison/present.ts:13</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L42">index.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/present.ts#L13">expression/comparison/present.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L42">index.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_suffix.html
+++ b/docs/modules/expression_comparison_suffix.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_suffix.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/suffix.ts#L11">expression/comparison/suffix.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L39">index.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/suffix.ts#L11">expression/comparison/suffix.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L39">index.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_comparison_undefined.html
+++ b/docs/modules/expression_comparison_undefined.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_comparison_undefined.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/comparison/undefined.ts#L13">expression/comparison/undefined.ts:13</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L41">index.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/comparison/undefined.ts#L13">expression/comparison/undefined.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L41">index.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_logical_and.html
+++ b/docs/modules/expression_logical_and.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_logical_and.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/and.ts#L11">expression/logical/and.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L43">index.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/and.ts#L11">expression/logical/and.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L43">index.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_logical_nor.html
+++ b/docs/modules/expression_logical_nor.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_logical_nor.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/nor.ts#L12">expression/logical/nor.ts:12</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L45">index.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/nor.ts#L12">expression/logical/nor.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L45">index.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_logical_not.html
+++ b/docs/modules/expression_logical_not.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_logical_not.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/not.ts#L11">expression/logical/not.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L47">index.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/not.ts#L11">expression/logical/not.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L47">index.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_logical_or.html
+++ b/docs/modules/expression_logical_or.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_logical_or.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/or.ts#L11">expression/logical/or.ts:11</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L44">index.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/or.ts#L11">expression/logical/or.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L44">index.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/expression_logical_xor.html
+++ b/docs/modules/expression_logical_xor.html
@@ -92,8 +92,8 @@
 					<div class="tsd-signature tsd-kind-icon">OPERATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="expression_logical_xor.html#operator" class="tsd-signature-type" data-tsd-kind="Variable">OPERATOR</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/expression/logical/xor.ts#L13">expression/logical/xor.ts:13</a></li>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/index.ts#L46">index.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/expression/logical/xor.ts#L13">expression/logical/xor.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/index.ts#L46">index.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/parser.html
+++ b/docs/modules/parser.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">Array<wbr>Input<span class="tsd-signature-symbol">:</span> <a href="parser.html#input" class="tsd-signature-type" data-tsd-kind="Type alias">Input</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L66">parser/index.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L66">parser/index.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">Expression<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">...</span><a href="parser.html#input" class="tsd-signature-type" data-tsd-kind="Type alias">Input</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L67">parser/index.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L67">parser/index.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><a href="parser.html#input" class="tsd-signature-type" data-tsd-kind="Type alias">Input</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">...</span><a href="parser.html#input" class="tsd-signature-type" data-tsd-kind="Type alias">Input</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/index.ts#L59">parser/index.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/index.ts#L59">parser/index.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/parser_options.html
+++ b/docs/modules/parser_options.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">option<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>operand<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L27">parser/options.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L27">parser/options.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Operator<wbr>Mapping<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L104">parser/options.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L104">parser/options.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/parser_options.options.html" class="tsd-signature-type" data-tsd-kind="Interface">Options</a><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L130">parser/options.ts:130</a></li>
+							<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L130">parser/options.ts:130</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L84">parser/options.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L84">parser/options.ts:84</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L98">parser/options.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L98">parser/options.ts:98</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/bb6789e/src/parser/options.ts#L94">parser/options.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/briza-insurance/illogical/blob/df21c75/src/parser/options.ts#L94">parser/options.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -141,6 +141,11 @@ describe('Operand - Value', () => {
       ['RefA{RefA}', '$RefA{RefA}'],
       ['RefB.{RefA}', '$RefB.{RefA}'],
       ['Ref{RefB}', '$Ref{RefB}'],
+      // Data type casting
+      ['RefH[{RefA}].sub{RefD}.(Number)', '$RefH[{RefA}].sub{RefD}.(Number)'],
+      ['RefA.(String)', '$RefA.(String)'],
+      ['RefJ.(String)', '$RefJ.(String)'],
+      ['RefJ.(Number)', '$RefJ.(Number)'],
     ])('%p should serialize to %p', (value, expected) => {
       expect(new Reference(value).serialize(defaultOptions)).toEqual(expected)
     })

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -144,7 +144,6 @@ describe('Operand - Value', () => {
       // Data type casting
       ['RefH[{RefA}].sub{RefD}.(Number)', '$RefH[{RefA}].sub{RefD}.(Number)'],
       ['RefA.(String)', '$RefA.(String)'],
-      ['RefJ.(String)', '$RefJ.(String)'],
       ['RefJ.(Number)', '$RefJ.(Number)'],
     ])('%p should serialize to %p', (value, expected) => {
       expect(new Reference(value).serialize(defaultOptions)).toEqual(expected)

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -155,7 +155,8 @@ export class Reference extends Operand {
    * {@link Evaluable.serialize}
    */
   serialize({ referenceSerialization }: Options): string {
-    return referenceSerialization(this.key)
+    const key = this.dataType ? `${this.key}.(${this.dataType})` : this.key
+    return referenceSerialization(key)
   }
 
   /**

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -51,8 +51,8 @@ export interface Options {
   referenceTransform: (operand: string) => string
 
   /**
-   * A function used to tranform ths stripped form of a reference into an
-   * annoteted version of the reference. This function should be the inverse
+   * A function used to transform the stripped form of a reference into an
+   * annotated version of the reference. This function should be the inverse
    * function of referenceTranform.
    *
    * referenceSerialization(referenceTransform("$Reference")) === '$Reference'

--- a/types/parser/options.d.ts
+++ b/types/parser/options.d.ts
@@ -23,8 +23,8 @@ export interface Options {
      */
     referenceTransform: (operand: string) => string;
     /**
-     * A function used to tranform ths stripped form of a reference into an
-     * annoteted version of the reference. This function should be the inverse
+     * A function used to transform the stripped form of a reference into an
+     * annotated version of the reference. This function should be the inverse
      * function of referenceTranform.
      *
      * referenceSerialization(referenceTransform("$Reference")) === '$Reference'


### PR DESCRIPTION
# Description
This fix ensures that the reference data type is serialized along with the key when `.simplify` is called.

### Test Coverage
- [x] unit