### PR TITLE
set babel env targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "presets": [
-    "@babel/env",
+    ["@babel/env", {
+      "targets": "> 1%, node 12"
+    }],
     "@babel/preset-typescript"
   ],
   "plugins": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # illogical changelog
 
+## 1.4.2
+- Change `@babel/env` preset target to `> 1%, node 12`
 ## 1.4.0
 
 - Add support for reference variable data type casting before expression evaluation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/readme.md
+++ b/readme.md
@@ -678,6 +678,10 @@ import {
 
 ## Breaking Changes
 
+### v1.4.2
+* Change on `@babel/env` preset to target `> 1%, node 12` this will remove some polyfills that were causing performance 
+problems in some projects.
+
 ### v1.2.0
 * Removed **strict** mode from the Engine constructor options.
 ```const engine = new Engine(strictMode, opts);``` -> ```const engine = new Engine(opts);```


### PR DESCRIPTION
# Description

Setting the target of the `@babel/env` preset to `> 1%, node 12`. This means browsers with trafic greater than 1% and node 12.

Why?

The default target is to transpile everything to support ES5 and this was causing performance issues in projects using illogical in node.

### Test Coverage
- [x] unit
