### PR TITLE
Limit comparison expressions operands to non-expressions evaluables only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.4.3
 
-- Prevent unexpected parsing of logical or comparison expression used as an operand in a comparison expression
+- Prevent unexpected parsing of any expression used as an operand in a comparison expression
 
 ## 1.4.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # illogical changelog
 
+## 1.4.3
+
+- Prevent unexpected parsing of logical or comparison expression used as an operand in a comparison expression
+
 ## 1.4.2
 
 - Change `@babel/env` preset target to `> 1%, node 12`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/src/parser/__test__/unit/index.test.ts
+++ b/src/parser/__test__/unit/index.test.ts
@@ -359,6 +359,21 @@ describe('Condition Engine - Parser', () => {
         new In(new Value(5), new Collection([new Value(5)])),
       ],
       [
+        [
+          defaultOptions.operatorMapping.get(OPERATOR_IN),
+          5,
+          [defaultOptions.operatorMapping.get(OPERATOR_EQ), 2, 2],
+        ],
+        new In(
+          new Value(5),
+          new Collection([
+            new Value(defaultOptions.operatorMapping.get(OPERATOR_EQ)),
+            new Value(2),
+            new Value(2),
+          ])
+        ),
+      ],
+      [
         [defaultOptions.operatorMapping.get(OPERATOR_NOT_IN), 5, [5]],
         new NotIn(new Value(5), new Collection([new Value(5)])),
       ],

--- a/src/parser/__test__/unit/index.test.ts
+++ b/src/parser/__test__/unit/index.test.ts
@@ -374,7 +374,7 @@ describe('Condition Engine - Parser', () => {
         [
           defaultOptions.operatorMapping.get(OPERATOR_OVERLAP),
           ['a', 'b'],
-          ['a'],
+          ['IN'],
         ],
         new Overlap(
           new Collection([new Value('a'), new Value('b')]),

--- a/src/parser/__test__/unit/index.test.ts
+++ b/src/parser/__test__/unit/index.test.ts
@@ -378,7 +378,7 @@ describe('Condition Engine - Parser', () => {
         ],
         new Overlap(
           new Collection([new Value('a'), new Value('b')]),
-          new Collection([new Value('a')])
+          new Collection([new Value('IN')])
         ),
       ],
       // Reference

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -247,8 +247,7 @@ export class Parser {
         return this.getOperand(raw)
     }
 
-    operandParser = operandParser.bind(this)
-    return expression(operands.map(operandParser))
+    return expression(operands.map(operandParser.bind(this)))
   }
 
   /**

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -130,6 +130,7 @@ export class Parser {
     }
 
     let expression: (operands: Evaluable[]) => Evaluable
+    let operandParser: (raw: Input) => Evaluable = this.getOperand
     const operator = (raw as ArrayInput)[0] as string
     const operands = (raw as ArrayInput).slice(1)
 
@@ -165,22 +166,27 @@ export class Parser {
       case this.opts.operatorMapping.get(OPERATOR_AND):
         expression = (operands: Evaluable[]): Evaluable =>
           logicalExpressionReducer(operands, true) || new And(operands)
+        operandParser = this.parseRawExp
         break
       case this.opts.operatorMapping.get(OPERATOR_OR):
         expression = (operands: Evaluable[]): Evaluable =>
           logicalExpressionReducer(operands, true) || new Or(operands)
+        operandParser = this.parseRawExp
         break
       case this.opts.operatorMapping.get(OPERATOR_NOR):
         expression = (operands: Evaluable[]): Evaluable =>
           logicalExpressionReducer(operands) || new Nor(operands)
+        operandParser = this.parseRawExp
         break
       case this.opts.operatorMapping.get(OPERATOR_XOR):
         expression = (operands: Evaluable[]): Evaluable =>
           logicalExpressionReducer(operands) || new Xor(operands)
+        operandParser = this.parseRawExp
         break
       case this.opts.operatorMapping.get(OPERATOR_NOT):
         expression = (operands: Evaluable[]): Evaluable =>
           logicalExpressionReducer(operands) || new Not(...operands)
+        operandParser = this.parseRawExp
         break
       /**
        * Comparison
@@ -241,11 +247,7 @@ export class Parser {
         return this.getOperand(raw)
     }
 
-    return expression(
-      operands.map((operand) => {
-        return this.parseRawExp(operand)
-      })
-    )
+    return expression(operands.map(operandParser.bind(this)))
   }
 
   /**

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -247,7 +247,8 @@ export class Parser {
         return this.getOperand(raw)
     }
 
-    return expression(operands.map(operandParser.bind(this)))
+    operandParser = operandParser.bind(this)
+    return expression(operands.map(operandParser))
   }
 
   /**


### PR DESCRIPTION
# Description
Prevent unexpected parsing of logical or comparison expression used as an operand in a comparison expression

**Comparison Expressions**, https://github.com/briza-insurance/illogical#comparison-expressions, expects operands to be https://github.com/briza-insurance/illogical#operand-types, i.e.:
- Value, https://github.com/briza-insurance/illogical#value
- Reference, https://github.com/briza-insurance/illogical#reference
- Collection, https://github.com/briza-insurance/illogical#collection

---

Sample Expression: `['IN', '$RefA', ['==', '$RefB', 5]]`

#### Parsing, BEFORE:
- **IN** (comparison expression)
  - left: `$RefA` (operand, reference)
  - right: **EQUAL** (comparison expression) **<-- unexpected parsing**
    - left: `$RefB` (operand, reference)
    - right: `5` (operand, value)

#### Parsing, AFTER:
- **IN** (comparison expression)
  - left: `$RefA` (operand, reference)
  - right: `['==', '$RefB', 5]` (operand, collection)

--- 

### Test Coverage
- [x] unit
- [x] Binder e2e tests - no regression 
- [x] analysis of all existing conditions
   - I've analyzed all existing conditions in our current codebase (questions + referred conditions) and there are no conditions which would use the unexpected compression expression operands.
   - Analyzed via script, double checked by @geoff448 @sebastianserrano 

#### References
- Closes #185