### PR TITLE
Feature/gus 1351 support date comparisons in illogical

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -383,56 +383,72 @@ engine.evaluate(['!=', 'circle', 'square']) // true
 
 Expression format: `[">", `[Left Operand](#operand-types), [Right Operand](#operand-types)`]`.
 
-> Valid operand types: number.
+> Valid operand types: number, string.
+
+- String comparison only supports ISO-8601 formatted dates.
 
 ```json
 [">", 10, 5]
+[">", "2023-01-01", "2022-12-31"]
 ```
 
 ```js
 engine.evaluate(['>', 10, 5]) // true
+engine.evaluate(['>', '2023-01-01', '2022-12-31']) // true
 ```
 
 #### Greater Than or Equal
 
 Expression format: `[">=", `[Left Operand](#operand-types), [Right Operand](#operand-types)`]`.
 
-> Valid operand types: number.
+> Valid operand types: number, string.
+
+- String comparison only supports ISO-8601 formatted dates.
 
 ```json
 [">=", 5, 5]
+[">=", "2023-01-01",  "2023-01-01"]
 ```
 
 ```js
 engine.evaluate(['>=', 5, 5]) // true
+engine.evaluate(['>=', '2023-01-01', '2023-01-01']) // true
 ```
 
 #### Less Than
 
 Expression format: `["<", `[Left Operand](#operand-types), [Right Operand](#operand-types)`]`.
 
-> Valid operand types: number.
+> Valid operand types: number, string.
+
+- String comparison only supports ISO-8601 formatted dates.
 
 ```json
 ["<", 5, 10]
+["<", "2022-12-31",  "2023-01-01"]
 ```
 
 ```js
 engine.evaluate(['<', 5, 10]) // true
+engine.evaluate(['<', '2022-12-31', '2023-01-01']) // true
 ```
 
 #### Less Than or Equal
 
 Expression format: `["<=", `[Left Operand](#operand-types), [Right Operand](#operand-types)`]`.
 
-> Valid operand types: number.
+> Valid operand types: number, string.
+
+- String comparison only supports ISO-8601 formatted dates.
 
 ```json
 ["<=", 5, 5]
+["<=", "2023-01-01",  "2023-01-01"]
 ```
 
 ```js
 engine.evaluate(['<=', 5, 5]) // true
+engine.evaluate(['<=', '2023-01-01', '2023-01-01']) // true
 ```
 
 #### In

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -32,3 +32,13 @@ export const toString = (value: Result): string | undefined => {
 
   return undefined
 }
+/**
+ * Convert a value to number if it's type is string, otherwise return NaN
+ * @param value value to be converted to number
+ */
+export const toDateNumber = (value: Result): number => {
+  if (isString(value)) {
+    return Date.parse(value)
+  }
+  return NaN
+}

--- a/src/expression/comparison/__test__/unit/eq.test.ts
+++ b/src/expression/comparison/__test__/unit/eq.test.ts
@@ -28,6 +28,11 @@ describe('Expression - Comparison - Equal', () => {
       operand(value),
       true,
     ]),
+    // Truthy date Cases
+    [operand('2023-01-01'), operand('2023-01-01'), true],
+    // Falsy date Cases
+    [operand('2023-01-01'), operand('2022-12-31'), false],
+    [operand('2023-01-01'), operand('2023-01-02'), false],
     // Falsy - different types - across all permutations
     ...permutation(primitives).map<[Operand, Operand, boolean]>(
       ([left, right]) => [operand(left), operand(right), false]

--- a/src/expression/comparison/__test__/unit/ge.test.ts
+++ b/src/expression/comparison/__test__/unit/ge.test.ts
@@ -23,7 +23,7 @@ describe('Expression - Comparison - Greater Than or Equal', () => {
     // Truthy date cases
     [operand('2023-01-01'), operand('2022-12-31'), true],
     [operand('2023-01-01'), operand('2023-01-01'), true],
-    // Truthy date cases
+    // Falsy date cases
     [operand('2023-01-01'), operand('2023-01-02'), false],
     // Falsy
     [operand(0), operand(1), false],

--- a/src/expression/comparison/__test__/unit/ge.test.ts
+++ b/src/expression/comparison/__test__/unit/ge.test.ts
@@ -20,6 +20,11 @@ describe('Expression - Comparison - Greater Than or Equal', () => {
     // Truthy
     [operand(1), operand(0), true],
     [operand(1), operand(1), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2022-12-31'), true],
+    [operand('2023-01-01'), operand('2023-01-01'), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2023-01-02'), false],
     // Falsy
     [operand(0), operand(1), false],
     // Falsy - non-comparable types

--- a/src/expression/comparison/__test__/unit/gt.test.ts
+++ b/src/expression/comparison/__test__/unit/gt.test.ts
@@ -19,6 +19,11 @@ describe('Expression - Comparison - Greater Than', () => {
   const testCases: [Operand, Operand, boolean][] = [
     // Truthy
     [operand(1), operand(0), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2022-12-31'), true],
+    // Falsy date cases
+    [operand('2023-01-01'), operand('2023-01-01'), false],
+    [operand('2023-01-01'), operand('2023-01-02'), false],
     // Falsy
     [operand(1), operand(1), false],
     [operand(0), operand(1), false],

--- a/src/expression/comparison/__test__/unit/le.test.ts
+++ b/src/expression/comparison/__test__/unit/le.test.ts
@@ -20,6 +20,11 @@ describe('Expression - Comparison - Less Than or Equal', () => {
     // Truthy
     [operand(0), operand(1), true],
     [operand(1), operand(1), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2023-01-01'), true],
+    [operand('2023-01-01'), operand('2023-01-02'), true],
+    // Falsy date cases
+    [operand('2023-01-01'), operand('2022-12-31'), false],
     // Falsy
     [operand(1), operand(0), false],
     // Falsy - non-comparable types

--- a/src/expression/comparison/__test__/unit/lt.test.ts
+++ b/src/expression/comparison/__test__/unit/lt.test.ts
@@ -19,6 +19,11 @@ describe('Expression - Comparison - Less Than', () => {
   const testCases: [Operand, Operand, boolean][] = [
     // Truthy
     [operand(0), operand(1), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2023-01-02'), true],
+    // Falsy date cases
+    [operand('2023-01-01'), operand('2022-12-31'), false],
+    [operand('2023-01-01'), operand('2023-01-01'), false],
     // Falsy
     [operand(1), operand(1), false],
     [operand(1), operand(0), false],

--- a/src/expression/comparison/__test__/unit/ne.test.ts
+++ b/src/expression/comparison/__test__/unit/ne.test.ts
@@ -35,6 +35,11 @@ describe('Expression - Comparison - Not Equal', () => {
     // Truthy
     [operand(1), operand(10), true],
     [operand('1'), operand('10'), true],
+    // Truthy date cases
+    [operand('2023-01-01'), operand('2022-12-31'), true],
+    [operand('2023-01-01'), operand('2023-01-02'), true],
+    // Falsy date cases
+    [operand('2023-01-01'), operand('2023-01-01'), false],
     // Array types, truthy in any case
     [new Collection([new Value(1)]), new Collection([new Value(1)]), true],
     [new Collection([new Value('1')]), new Collection([new Value('1')]), true],

--- a/src/expression/comparison/ge.ts
+++ b/src/expression/comparison/ge.ts
@@ -1,5 +1,6 @@
 import { Evaluable, Result } from '../../common/evaluable'
 import { isNumber } from '../../common/type-check'
+import { toDateNumber } from '../../common/util'
 import { Comparison } from '../comparison'
 
 // Operator key
@@ -29,6 +30,13 @@ export class GreaterThanOrEqual extends Comparison {
     if (isNumber(left) && isNumber(right)) {
       return (left as number) >= (right as number)
     }
+
+    const leftDate = toDateNumber(left),
+      rightDate = toDateNumber(right)
+    if (leftDate && rightDate) {
+      return leftDate >= rightDate
+    }
+
     return false
   }
 }

--- a/src/expression/comparison/gt.ts
+++ b/src/expression/comparison/gt.ts
@@ -1,5 +1,6 @@
 import { Evaluable, Result } from '../../common/evaluable'
 import { isNumber } from '../../common/type-check'
+import { toDateNumber } from '../../common/util'
 import { Comparison } from '../comparison'
 
 // Operator key
@@ -29,6 +30,13 @@ export class GreaterThan extends Comparison {
     if (isNumber(left) && isNumber(right)) {
       return (left as number) > (right as number)
     }
+
+    const leftDate = toDateNumber(left),
+      rightDate = toDateNumber(right)
+    if (leftDate && rightDate) {
+      return leftDate > rightDate
+    }
+
     return false
   }
 }

--- a/src/expression/comparison/le.ts
+++ b/src/expression/comparison/le.ts
@@ -1,7 +1,7 @@
 import { Evaluable, Result } from '../../common/evaluable'
 import { isNumber } from '../../common/type-check'
+import { toDateNumber } from '../../common/util'
 import { Comparison } from '../comparison'
-
 // Operator key
 export const OPERATOR = Symbol('LE')
 
@@ -29,6 +29,13 @@ export class LessThanOrEqual extends Comparison {
     if (isNumber(left) && isNumber(right)) {
       return (left as number) <= (right as number)
     }
+
+    const leftDate = toDateNumber(left),
+      rightDate = toDateNumber(right)
+    if (leftDate && rightDate) {
+      return leftDate <= rightDate
+    }
+
     return false
   }
 }

--- a/src/expression/comparison/lt.ts
+++ b/src/expression/comparison/lt.ts
@@ -1,7 +1,7 @@
 import { Evaluable, Result } from '../../common/evaluable'
 import { isNumber } from '../../common/type-check'
+import { toDateNumber } from '../../common/util'
 import { Comparison } from '../comparison'
-
 // Operator key
 export const OPERATOR = Symbol('LT')
 
@@ -29,6 +29,13 @@ export class LessThan extends Comparison {
     if (isNumber(left) && isNumber(right)) {
       return (left as number) < (right as number)
     }
+
+    const leftDate = toDateNumber(left),
+      rightDate = toDateNumber(right)
+    if (leftDate && rightDate) {
+      return leftDate < rightDate
+    }
+
     return false
   }
 }

--- a/types/common/util.d.ts
+++ b/types/common/util.d.ts
@@ -9,3 +9,8 @@ export declare const toNumber: (value: Result) => number | undefined;
  * @param value value to be converted to string
  */
 export declare const toString: (value: Result) => string | undefined;
+/**
+ * Convert a value to number if it's type is string, otherwise return NaN
+ * @param value value to be converted to number
+ */
+export declare const toDateNumber: (value: Result) => number;


### PR DESCRIPTION
# Description

Comparison Expressions updated to support string comparison for ISO-8601 formatted dates. 

- This change effects operators `>`, `>=`, `<`, and `<=`. 

**Comparison expressions**
```json
[">", "2023-01-01", "2022-12-31"]
[">=", "2023-01-01",  "2023-01-01"]
["<", "2022-12-31",  "2023-01-01"]
["<=", "2023-01-01",  "2023-01-01"]
```


**Comparison expressions evaluation**
```js
engine.evaluate(['>', '2023-01-01', '2022-12-31']) // true
engine.evaluate(['>=', '2023-01-01', '2023-01-01']) // true
engine.evaluate(['<', '2022-12-31', '2023-01-01']) // true
engine.evaluate(['<=', '2023-01-01', '2023-01-01']) // true

```


### Test Coverage
- [x] unit

#### References
- Closes [GUS-1351](https://linear.app/briza/issue/GUS-1351/support-date-comparisons-in-illogical)