### PR TITLE
GUS-864 update readme to include example usage of double references

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # illogical changelog
 
+## 1.5.7
+
+- Update documentation to include example of comparison operator with two references
+- Fix linting issues
+
 ## 1.5.6
 
 - Comparison Expressions updated to support string comparison for ISO-8601 formatted dates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/readme.md
+++ b/readme.md
@@ -331,11 +331,12 @@ The reference operand must be prefixed with `$` symbol, e.g.: `$name`. This migh
 
 **Example**
 
-| Expression                    | Data Context      |
-| ----------------------------- | ----------------- |
-| `['==', '$age', 21]`          | `{age: 21}`       |
-| `['==', 'circle', '$shape'] ` | `{age: 'circle'}` |
-| `['==', '$visible', true]`    | `{visible: true}` |
+| Expression                    | Data Context                          |
+| ----------------------------- | ------------------------------------- |
+| `['==', '$age', 21]`          | `{age: 21}`                           |
+| `['==', 'circle', '$shape'] ` | `{shape: 'circle'}`                   |
+| `['==', '$visible', true]`    | `{visible: true}`                     |
+| `['==', '$circle', '$shape']` | `{circle: 'circle', shape: 'circle'}` |
 
 #### Collection
 

--- a/src/__test__/unit/index.test.ts
+++ b/src/__test__/unit/index.test.ts
@@ -164,7 +164,7 @@ describe('Condition Engine', () => {
         ctx: Context,
         expected: boolean | Input,
         strictKeys?: string[],
-        optionalKeys?: string[]
+        optionalKeys?: string[],
       ]
     >([
       [['==', '$a', '$b'], { a: 10, b: 20 }, false, []],

--- a/src/expression/logical/__test__/unit/not.test.ts
+++ b/src/expression/logical/__test__/unit/not.test.ts
@@ -22,7 +22,7 @@ describe('Expression - Logical - Not', () => {
     )
 
     test.each([[[]], [[operand(true), operand(false)]], [[operand(0)]]] as [
-      Evaluable[]
+      Evaluable[],
     ][])('%p should throw', (operands) => {
       expect(() => new Not(...operands).evaluate({})).toThrowError()
     })

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -90,7 +90,7 @@ describe('Operand - Value', () => {
         value: string,
         expected: Result | Reference,
         strictKeys?: string[],
-        optionalKeys?: string[]
+        optionalKeys?: string[],
       ]
     >([
       // Existing


### PR DESCRIPTION
# Description

- add missing explicit documentation / example usages for two references in a comparison operator

### Test Coverage
- [x] unit

#### References
- Part of [GUS-864](https://linear.app/briza/issue/GUS-864/breaking-change-btis-yearsexperience-add-kick-out-conditions-andor)