### PR TITLE
Add the new syntax for reference keys that contain dot delimiter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,26 @@ The evaluation data context is used to provide the expression with variable refe
 To reference the nested reference, please use "." delimiter, e.g.:
 `$address.city`
 
+If the key of the nested reference includes the "." delimiter, please wrap the whole key with backticks `` ` ``, e.g.:
+`` $address.`city.code` `` can reference the object
+```javascript
+{
+  address: {
+    'city.code': 'TOR'
+  }
+}
+```
+
+`` $address.`city.code[0]` `` can reference the object
+```javascript
+{
+  address: {
+    'city.code': ['TOR']
+  }
+}
+```
+when the value of the nested reference is an array.
+
 #### Accessing Array Element:
 
 `$options[1]`

--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,7 @@ If the key of the nested reference includes the "." delimiter, please wrap the w
 }
 ```
 
-`` $address.`city.code[0]` `` can reference the object
+`` $address.`city.code`[0] `` can reference the object
 ```javascript
 {
   address: {

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -26,6 +26,9 @@ describe('Operand - Value', () => {
           subSubE: [{ subSubSubE: 6 }],
         },
       ],
+      // key with backticks are acceptable
+      'sub`E.dotKey': { subSubE: 7 },
+      'sub`E.dotKey`': { subSubE: 8 },
     },
     RefD: 'A',
     RefE: 'D',
@@ -69,6 +72,8 @@ describe('Operand - Value', () => {
       // yield an undefined since this is a wrong syntax to access array item for a key that contains a dot
       ['RefC.`subD.dotKey[0]`.subSubD', undefined],
       ['RefC.`subD.dotKey`[0].subSubE[0].subSubSubE', 6],
+      ['RefC.`sub`E.dotKey`.subSubE', 7],
+      ['RefC.`sub`E.dotKey``.subSubE', 8],
       // Missing
       ['RefB', undefined],
       ['RefC.subC', undefined],

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -17,6 +17,15 @@ describe('Operand - Value', () => {
       subB: {
         subSubA: 3,
       },
+      'subC.dotKey': {
+        subSubC: 4,
+      },
+      'subD.dotKey': [
+        {
+          subSubD: 5,
+          subSubE: [{ subSubSubE: 6 }],
+        },
+      ],
     },
     RefD: 'A',
     RefE: 'D',
@@ -55,6 +64,9 @@ describe('Operand - Value', () => {
       // Nested
       ['RefC.subA', 2],
       ['RefC.subB.subSubA', 3],
+      ['RefC.`subC.dotKey`.subSubC', 4],
+      ['RefC.`subD.dotKey[0]`.subSubD', 5],
+      ['RefC.`subD.dotKey[0]`.subSubE[0].subSubSubE', 6],
       // Missing
       ['RefB', undefined],
       ['RefC.subC', undefined],

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -65,8 +65,10 @@ describe('Operand - Value', () => {
       ['RefC.subA', 2],
       ['RefC.subB.subSubA', 3],
       ['RefC.`subC.dotKey`.subSubC', 4],
-      ['RefC.`subD.dotKey[0]`.subSubD', 5],
-      ['RefC.`subD.dotKey[0]`.subSubE[0].subSubSubE', 6],
+      ['RefC.`subD.dotKey`[0].subSubD', 5],
+      // yield an undefined since this is a wrong syntax to access array item for a key that contains a dot
+      ['RefC.`subD.dotKey[0]`.subSubD', undefined],
+      ['RefC.`subD.dotKey`[0].subSubE[0].subSubSubE', 6],
       // Missing
       ['RefB', undefined],
       ['RefC.subC', undefined],

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -9,24 +9,30 @@ type Keys = (string | number)[]
 const keyWithArrayIndexRegex =
   /^(?<currentKey>[^[\]]+?)(?<indexes>(?:\[\d+])+)?$/
 const arrayIndexRegex = /\[(\d+)]/g
-const parseKey = (key: string): Keys =>
-  key.split('.').flatMap((key) => {
-    const parseResult = keyWithArrayIndexRegex.exec(key)
-    const keys: Keys = []
-    if (parseResult) {
-      keys.push(parseResult?.groups?.currentKey ?? key)
-
-      const rawIndexes = parseResult?.groups?.indexes
-      if (rawIndexes) {
-        for (const indexResult of rawIndexes.matchAll(arrayIndexRegex)) {
-          keys.push(parseInt(indexResult[1]))
+const parseKey = (key: string): Keys => {
+  const keys = key.match(/(`.+`|[^`.]+)/g)
+  return !keys
+    ? []
+    : keys.flatMap((key) => {
+        if (key.startsWith('`') && key.endsWith('`')) {
+          key = key.slice(1, -1)
         }
-      }
-    } else {
-      keys.push(key)
-    }
-    return keys
-  })
+        const parseResult = keyWithArrayIndexRegex.exec(key)
+        const keys: Keys = []
+        if (parseResult) {
+          keys.push(parseResult?.groups?.currentKey ?? key)
+          const rawIndexes = parseResult?.groups?.indexes
+          if (rawIndexes) {
+            for (const indexResult of rawIndexes.matchAll(arrayIndexRegex)) {
+              keys.push(parseInt(indexResult[1]))
+            }
+          }
+        } else {
+          keys.push(key)
+        }
+        return keys
+      })
+}
 
 const complexKeyExpression = /{([^{}]+)}/
 function extractComplexKeys(ctx: Context, key: string): Keys | undefined {


### PR DESCRIPTION
# Description
A clear and concise description of introduced changes.

### Test Coverage
- [x] unit

#### References
- Closes ```[ISSUE-ID]```
