### PR TITLE
GUS-2552: Fix Illogical OVERLAP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # illogical changelog
 
+## 1.5.9
+
+- Modify OVERLAP expression such that the OVERLAP of two empty arrays returns true
+
 ## 1.5.8
 
 - Introduce the backtick syntax for condition referencing keys that contain dot delimiters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/src/expression/comparison/__test__/unit/overlap.test.ts
+++ b/src/expression/comparison/__test__/unit/overlap.test.ts
@@ -34,6 +34,7 @@ describe('Expression - Comparison - Overlap', () => {
       new Collection([new Value('1'), new Value('2')]),
       true,
     ],
+    [new Collection([]), new Collection([]), true],
     // Truthy - Bi-directional
     [
       new Collection([new Value(1), new Value(2), new Value(5)]),

--- a/src/expression/comparison/overlap.ts
+++ b/src/expression/comparison/overlap.ts
@@ -40,6 +40,10 @@ export class Overlap extends Comparison {
 
     const leftArray = left as (string | number)[]
     const rightArray = right as (string | number)[]
+
+    if (leftArray.length === 0 && rightArray.length === 0) {
+      return true
+    }
     return leftArray.some((element) => rightArray.includes(element))
   }
 


### PR DESCRIPTION
# Description
Make it so that OVERLAP returns true if you are evaluating 2 empty arrays

### Test Coverage
- [ ] unit

#### References
[GUS-2552](https://linear.app/briza/issue/GUS-2552/fix-illogical-overlap)