### PR TITLE
npm pkg fix + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ npm-debug.log
 .idea
 
 coverage
+
+.npmrc

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:briza-insurance/illogical.git"
+    "url": "git+ssh://git@github.com/briza-insurance/illogical.git"
   },
   "bugs": {
     "url": "https://github.com/briza-insurance/illogical/issues"


### PR DESCRIPTION
# Description
- npm pkg fix
- gitignore to prevent npm configs to be versioned
- Not worth a release on its own