### PR TITLE
Bugfix on Arithmetic evaluation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # illogical changelog
 
+## 1.6.1
+
+- Bugfix on Arithmetic evaluate. Returns false when ContextValue is not present in the Context.
+
 ## 1.6.0
 
 - Added support for Arithmetic expressions within other Comparison expressions. This allows for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@briza/illogical",
-  "version": "1.5.9",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@briza/illogical",
-      "version": "1.5.9",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/illogical",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A micro conditional javascript engine used to parse the raw logical and comparison expressions, evaluate the expression in the given data context, and provide access to a text form of the given expressions.",
   "main": "lib/illogical.js",
   "module": "lib/illogical.esm.js",

--- a/src/__test__/unit/index.test.ts
+++ b/src/__test__/unit/index.test.ts
@@ -83,6 +83,27 @@ describe('Condition Engine', () => {
       expect(engine.evaluate(expression, context)).toEqual(expected)
     })
 
+    test.each<[ExpressionInput, Context, boolean]>([
+      [['==', ['+', 5, 5, 5], 15], {}, true],
+      [['==', ['+', '$RefA', 5], 15], {}, false],
+      [['==', ['+', '$RefA', 5], 15], { RefA: 10 }, true],
+      [['==', ['+', '$RefA', 5], 15], { RefA: 0 }, false],
+      [['>', ['-', '$RefA', 5], 15], {}, false],
+      [['>', '$RefA', 15], {}, false],
+      [['IN', '$RefA', ['option1', 'option2']], {}, false],
+      [['OVERLAP', ['$RefA', '$RefB'], ['option1', 'option2']], {}, false],
+      [['PRESENT', '$RefA'], {}, false],
+      [['UNDEFINED', '$RefA'], {}, true],
+      [
+        ['AND', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']],
+        { RefB: 'present' },
+        true,
+      ],
+      [['OR', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']], {}, true],
+    ])('%p should evaluate to %p', (expression, context, expectedResult) => {
+      expect(engine.evaluate(expression, context)).toEqual(expectedResult)
+    })
+
     test.each([
       // Operators with invalid operands
       [[OPERATOR_EQ]],

--- a/src/expression/arithmetic/__test__/unit/divide.test.ts
+++ b/src/expression/arithmetic/__test__/unit/divide.test.ts
@@ -8,7 +8,7 @@ import { Divide, OPERATOR } from '../../divide'
 describe('Expression - Arithmetic - Divide', () => {
   describe('constructor', () => {
     test.each([[[]], [[operand(5)]]])('arguments %p should throw', (args) => {
-      expect(() => new Divide(...args)).toThrowError(
+      expect(() => new Divide(...args)).toThrow(
         'divide expression requires at least 2 operands'
       )
     })
@@ -27,6 +27,8 @@ describe('Expression - Arithmetic - Divide', () => {
     [2.0999999099999913, operand(2.333333), operand(1.111111)],
     [4, operand(0.4), operand(0.1)],
     [1, operand(1.333), operand(1.333)],
+    [false, operand(null), operand(1)],
+    [false, operand(undefined), operand(1)],
   ]
 
   describe('evaluate', () => {
@@ -43,11 +45,9 @@ describe('Expression - Arithmetic - Divide', () => {
       [operand('string1'), operand(2)],
       [operand('string1'), operand('string2')],
       [operand(1), operand('string2')],
-      [operand(null), operand(1)],
-      [operand(undefined), operand(1)],
     ])('%p and %p should throw', (...operands) => {
-      expect(() => new Divide(...operands).evaluate({})).toThrowError(
-        'operands must be numbers for divide'
+      expect(() => new Divide(...operands).evaluate({})).toThrow(
+        'operands must be numbers for Divide'
       )
     })
   })
@@ -102,7 +102,7 @@ describe('Expression - Arithmetic - Divide', () => {
           ...defaultOptions,
           operatorMapping: new Map<symbol, string>(),
         })
-      ).toThrowError()
+      ).toThrow()
     })
   })
 })

--- a/src/expression/arithmetic/__test__/unit/multiply.test.ts
+++ b/src/expression/arithmetic/__test__/unit/multiply.test.ts
@@ -8,7 +8,7 @@ import { Multiply, OPERATOR } from '../../multiply'
 describe('Expression - Arithmetic - Multiply', () => {
   describe('constructor', () => {
     test.each([[[]], [[operand(5)]]])('arguments %p should throw', (args) => {
-      expect(() => new Multiply(...args)).toThrowError(
+      expect(() => new Multiply(...args)).toThrow(
         'multiply expression requires at least 2 operands'
       )
     })
@@ -27,6 +27,8 @@ describe('Expression - Arithmetic - Multiply', () => {
     [2.592591962963, operand(2.333333), operand(1.111111)],
     [0.04, operand(0.4), operand(0.1)],
     [1.776889, operand(1.333), operand(1.333)],
+    [false, operand(null), operand(1)],
+    [false, operand(undefined), operand(1)],
   ]
 
   describe('evaluate', () => {
@@ -43,11 +45,9 @@ describe('Expression - Arithmetic - Multiply', () => {
       [operand('string1'), operand(2)],
       [operand('string1'), operand('string2')],
       [operand(1), operand('string2')],
-      [operand(null), operand(1)],
-      [operand(undefined), operand(1)],
     ])('%p and %p should throw', (...operands) => {
-      expect(() => new Multiply(...operands).evaluate({})).toThrowError(
-        'operands must be numbers for multiply'
+      expect(() => new Multiply(...operands).evaluate({})).toThrow(
+        'operands must be numbers for Multiply'
       )
     })
   })
@@ -102,7 +102,7 @@ describe('Expression - Arithmetic - Multiply', () => {
           ...defaultOptions,
           operatorMapping: new Map<symbol, string>(),
         })
-      ).toThrowError()
+      ).toThrow()
     })
   })
 })

--- a/src/expression/arithmetic/__test__/unit/subtract.test.ts
+++ b/src/expression/arithmetic/__test__/unit/subtract.test.ts
@@ -8,7 +8,7 @@ import { OPERATOR, Subtract } from '../../subtract'
 describe('Expression - Arithmetic - Subtract', () => {
   describe('constructor', () => {
     test.each([[[]], [[operand(5)]]])('arguments %p should throw', (args) => {
-      expect(() => new Subtract(...args)).toThrowError(
+      expect(() => new Subtract(...args)).toThrow(
         'subtract expression requires at least 2 operands'
       )
     })
@@ -27,6 +27,8 @@ describe('Expression - Arithmetic - Subtract', () => {
     [1.222222, operand(2.333333), operand(1.111111)],
     [0.3, operand(0.4), operand(0.1)],
     [0, operand(1.333), operand(1.333)],
+    [false, operand(null), operand(1)],
+    [false, operand(undefined), operand(1)],
   ]
 
   describe('evaluate', () => {
@@ -43,11 +45,9 @@ describe('Expression - Arithmetic - Subtract', () => {
       [operand('string1'), operand(2)],
       [operand('string1'), operand('string2')],
       [operand(1), operand('string2')],
-      [operand(null), operand(1)],
-      [operand(undefined), operand(1)],
     ])('%p and %p should throw', (...operands) => {
-      expect(() => new Subtract(...operands).evaluate({})).toThrowError(
-        'operands must be numbers for subtract'
+      expect(() => new Subtract(...operands).evaluate({})).toThrow(
+        'operands must be numbers for Subtract'
       )
     })
   })
@@ -102,7 +102,7 @@ describe('Expression - Arithmetic - Subtract', () => {
           ...defaultOptions,
           operatorMapping: new Map<symbol, string>(),
         })
-      ).toThrowError()
+      ).toThrow()
     })
   })
 })

--- a/src/expression/arithmetic/__test__/unit/sum.test.ts
+++ b/src/expression/arithmetic/__test__/unit/sum.test.ts
@@ -8,7 +8,7 @@ import { OPERATOR, Sum } from '../../sum'
 describe('Expression - Arithmetic - Sum', () => {
   describe('constructor', () => {
     test.each([[[]], [[operand(5)]]])('arguments %p should throw', (args) => {
-      expect(() => new Sum(...args)).toThrowError(
+      expect(() => new Sum(...args)).toThrow(
         'sum expression requires at least 2 operands'
       )
     })
@@ -26,6 +26,8 @@ describe('Expression - Arithmetic - Sum', () => {
     [0.3, operand(0.2), operand(0.1)],
     [4, operand(1.2), operand(2.8)],
     [0, operand(1.333), operand(-1.333)],
+    [false, operand(null), operand(1)],
+    [false, operand(undefined), operand(1)],
   ]
 
   describe('evaluate', () => {
@@ -42,11 +44,9 @@ describe('Expression - Arithmetic - Sum', () => {
       [operand('string1'), operand(2)],
       [operand('string1'), operand('string2')],
       [operand(1), operand('string2')],
-      [operand(null), operand(1)],
-      [operand(undefined), operand(1)],
     ])('%p and %p should throw', (...operands) => {
-      expect(() => new Sum(...operands).evaluate({})).toThrowError(
-        'operands must be numbers for sum'
+      expect(() => new Sum(...operands).evaluate({})).toThrow(
+        'operands must be numbers for Sum'
       )
     })
   })
@@ -101,7 +101,7 @@ describe('Expression - Arithmetic - Sum', () => {
           ...defaultOptions,
           operatorMapping: new Map<symbol, string>(),
         })
-      ).toThrowError()
+      ).toThrow()
     })
   })
 })

--- a/src/expression/arithmetic/divide.ts
+++ b/src/expression/arithmetic/divide.ts
@@ -1,5 +1,4 @@
 import { Evaluable, Result } from '../../common/evaluable'
-import { areAllNumbers } from '../../common/type-check'
 import { Operand } from '../../operand'
 import { Arithmetic } from '.'
 
@@ -27,12 +26,12 @@ export class Divide extends Arithmetic {
   }
 
   operate(results: Result[]): Result {
-    if (!areAllNumbers(results)) {
-      throw new Error('operands must be numbers for divide')
+    const presentResults = this.getResultValues(results)
+
+    if (presentResults === false) {
+      return false
     }
 
-    const result = results.reduce((acc, result) => acc / result)
-
-    return result
+    return presentResults.reduce((acc, result) => acc / result)
   }
 }

--- a/src/expression/arithmetic/index.ts
+++ b/src/expression/arithmetic/index.ts
@@ -5,7 +5,7 @@ import {
   Result,
   SimplifyArgs,
 } from '../../common/evaluable'
-import { areAllResults } from '../../common/type-check'
+import { areAllNumbers, areAllResults } from '../../common/type-check'
 import { Operand } from '../../operand'
 import { ExpressionInput } from '../../parser'
 import { Options } from '../../parser/options'
@@ -27,6 +27,31 @@ export abstract class Arithmetic implements Evaluable {
     protected readonly operatorSymbol: symbol,
     protected readonly operands: Operand[]
   ) {}
+
+  /**
+   * Helper function to assist with arithmetic evaluation. Ensures that all
+   * operands are present and are numbers. Throws error if any operand is not a
+   * number.
+   *
+   * @param {Result[]} results
+   * @returns {number[] | false} false if any operand is missing, otherwise the
+   *   array of numbers
+   */
+  protected getResultValues(results: Result[]): number[] | false {
+    const presentValues = results.filter(
+      (result) => result !== null && result !== undefined
+    )
+    // If we have missing context values the result must be false
+    if (presentValues.length !== results.length) {
+      return false
+    }
+
+    if (!areAllNumbers(presentValues)) {
+      throw new Error(`operands must be numbers for ${this.constructor.name}`)
+    }
+
+    return presentValues
+  }
 
   /**
    * Performs the arithmetic operation on the operands evaluated values.

--- a/src/expression/arithmetic/multiply.ts
+++ b/src/expression/arithmetic/multiply.ts
@@ -1,5 +1,4 @@
 import { Evaluable, Result } from '../../common/evaluable'
-import { areAllNumbers } from '../../common/type-check'
 import { Operand } from '../../operand'
 import { Arithmetic } from '.'
 import { operateWithExpectedDecimals } from './operateWithExpectedDecimals'
@@ -30,10 +29,13 @@ export class Multiply extends Arithmetic {
   }
 
   operate(results: Result[]): Result {
-    if (!areAllNumbers(results)) {
-      throw new Error('operands must be numbers for multiply')
+    const presentResults = this.getResultValues(results)
+
+    if (presentResults === false) {
+      return false
     }
-    return results.reduce((acc, result) =>
+
+    return presentResults.reduce((acc, result) =>
       multiplyWithExpectedDecimals(acc, result)
     )
   }

--- a/src/expression/arithmetic/subtract.ts
+++ b/src/expression/arithmetic/subtract.ts
@@ -1,5 +1,4 @@
 import { Evaluable, Result } from '../../common/evaluable'
-import { areAllNumbers } from '../../common/type-check'
 import { Operand } from '../../operand'
 import { Arithmetic } from '.'
 import { operateWithExpectedDecimals } from './operateWithExpectedDecimals'
@@ -30,10 +29,13 @@ export class Subtract extends Arithmetic {
   }
 
   operate(results: Result[]): Result {
-    if (!areAllNumbers(results)) {
-      throw new Error('operands must be numbers for subtract')
+    const presentResults = this.getResultValues(results)
+
+    if (presentResults === false) {
+      return false
     }
-    return results.reduce((acc, result) =>
+
+    return presentResults.reduce((acc, result) =>
       subtractWithExpectedDecimals(acc, result)
     )
   }

--- a/src/expression/arithmetic/sum.ts
+++ b/src/expression/arithmetic/sum.ts
@@ -1,5 +1,4 @@
 import { Evaluable, Result } from '../../common/evaluable'
-import { areAllNumbers } from '../../common/type-check'
 import { Operand } from '../../operand'
 import { Arithmetic } from '.'
 import { operateWithExpectedDecimals } from './operateWithExpectedDecimals'
@@ -30,9 +29,14 @@ export class Sum extends Arithmetic {
   }
 
   operate(results: Result[]): Result {
-    if (!areAllNumbers(results)) {
-      throw new Error('operands must be numbers for sum')
+    const presentResults = this.getResultValues(results)
+
+    if (presentResults === false) {
+      return false
     }
-    return results.reduce((acc, result) => addWithExpectedDecimals(acc, result))
+
+    return presentResults.reduce((acc, result) =>
+      addWithExpectedDecimals(acc, result)
+    )
   }
 }

--- a/types/expression/arithmetic/index.d.ts
+++ b/types/expression/arithmetic/index.d.ts
@@ -18,6 +18,16 @@ export declare abstract class Arithmetic implements Evaluable {
      */
     constructor(operator: string, operatorSymbol: symbol, operands: Operand[]);
     /**
+     * Helper function to assist with arithmetic evaluation. Ensures that all
+     * operands are present and are numbers. Throws error if any operand is not a
+     * number.
+     *
+     * @param {Result[]} results
+     * @returns {number[] | false} false if any operand is missing, otherwise the
+     *   array of numbers
+     */
+    protected getResultValues(results: Result[]): number[] | false;
+    /**
      * Performs the arithmetic operation on the operands evaluated values.
      * @param {Result[]} results Operand result values.
      * @returns {Result}


### PR DESCRIPTION
# Description
- Bugfix on Arithmetic evaluate. Returns false when ContextValue is not present in the Context.

### Test Coverage
- [x] unit

#### References
- Closes ```GUS-3940```