### PR TITLE
GUS-5917 Cache references

### DIFF
--- a/src/__test__/unit/index.test.ts
+++ b/src/__test__/unit/index.test.ts
@@ -17,1236 +17,1310 @@ import { OPERATOR as OPERATOR_OR } from '../../expression/logical/or'
 import { OPERATOR as OPERATOR_XOR } from '../../expression/logical/xor'
 import { ExpressionInput, Input } from '../../parser'
 
-describe('Condition Engine', () => {
-  const engine = new Engine()
+describe.each([false, true])(
+  'Condition Engine with cache %s',
+  (cacheReferences) => {
+    const engine = new Engine({ cacheReferences })
 
-  describe('evaluate', () => {
-    test.each(
-      [
+    describe('evaluate', () => {
+      test.each(
+        [
+          // OVERLAP
+          ...[
+            [
+              'OVERLAP',
+              ['$State1', '$State2', '$State3', '$State4'],
+              ['TX', 'CA'],
+            ],
+          ].map((expression) => [
+            [expression, { State1: 'TX' }, true],
+            [expression, { State1: 'AL' }, false],
+            [
+              expression,
+              { State1: 'TX', State2: 'AL', State3: 'CA', State4: 'CO' },
+              true,
+            ],
+            [
+              expression,
+              { State1: 'MI', State2: 'RI', State3: 'NY', State4: 'NY' },
+              false,
+            ],
+          ]),
+          // UNDEFINED
+          ...[['UNDEFINED', '$Name']].map((expression) => [
+            [expression, { Name: undefined }, true],
+            [expression, { Name: 'David' }, false],
+            [expression, { Name: null }, false],
+          ]),
+          // PRESENT
+          ...[['PRESENT', '$Name']].map((expression) => [
+            [expression, { Name: undefined }, false],
+            [expression, { Name: 'David' }, true],
+            [expression, { Name: null }, false],
+            [expression, { Name: false }, true],
+            [expression, { Name: { obj: 'obj' } }, true],
+          ]),
+          // NOT UNDEFINED
+          ...[['NOT', ['UNDEFINED', '$Name']]].map((expression) => [
+            [expression, { Name: undefined }, false],
+            [expression, { Name: 'David' }, true],
+            [expression, { Name: null }, true],
+          ]),
+          // NOT OVERLAP
+          ...[
+            [
+              'NOT',
+              [
+                'OVERLAP',
+                ['$region1', '$region2'],
+                ['FL', 'LA', 'NY', 'RI', 'TX'],
+              ],
+            ],
+          ].map((expression) => [
+            [expression, { region1: 'FL', region2: 'MI' }, false],
+            [expression, { region1: 'AL', region2: 'MI' }, true],
+          ]),
+        ].flat() as [ExpressionInput, Context, boolean][]
+      )('%p in %p should evaluate as %p', (expression, context, expected) => {
+        expect(engine.evaluate(expression, context)).toEqual(expected)
+      })
+
+      test.each<[ExpressionInput, Context, boolean]>([
+        [['==', ['+', 5, 5, 5], 15], {}, true],
+        [['==', ['+', '$RefA', 5], 15], {}, false],
+        [['==', ['+', '$RefA', 5], 15], { RefA: 10 }, true],
+        [['==', ['+', '$RefA', 5], 15], { RefA: 0 }, false],
+        [['>', ['-', '$RefA', 5], 15], {}, false],
+        [['>', '$RefA', 15], {}, false],
+        [['IN', '$RefA', ['option1', 'option2']], {}, false],
+        [['OVERLAP', ['$RefA', '$RefB'], ['option1', 'option2']], {}, false],
+        [['PRESENT', '$RefA'], {}, false],
+        [['UNDEFINED', '$RefA'], {}, true],
+        [
+          ['AND', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']],
+          { RefB: 'present' },
+          true,
+        ],
+        [['OR', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']], {}, true],
+      ])('%p should evaluate to %p', (expression, context, expectedResult) => {
+        expect(engine.evaluate(expression, context)).toEqual(expectedResult)
+      })
+
+      test.each([
+        // Operators with invalid operands
+        [[OPERATOR_EQ]],
+        [[OPERATOR_EQ, 5]],
+        [[OPERATOR_EQ, 5, 5, 5]],
+        [[OPERATOR_NE]],
+        [[OPERATOR_GT]],
+        [[OPERATOR_GE]],
+        [[OPERATOR_LT]],
+        [[OPERATOR_LE]],
+        [[OPERATOR_IN]],
+        [[OPERATOR_NOT_IN]],
+        [[OPERATOR_PREFIX]],
+        [[OPERATOR_SUFFIX]],
+        [[OPERATOR_AND]],
+        [[OPERATOR_OR]],
+        [[OPERATOR_NOR]],
+        [[OPERATOR_XOR]],
+        [[OPERATOR_SUM]],
+        [[OPERATOR_SUM, 5, 5, 5]],
+      ])('%p should throw', (expression) => {
+        expect(() =>
+          engine.evaluate(expression as ExpressionInput, {})
+        ).toThrowError()
+      })
+
+      test.each<[ExpressionInput]>([
+        [['+', 5, 5]],
+        [['-', 5, 5]],
+        [['*', 5, 5]],
+        [['/', 5, 5]],
+      ])('%p should throw', (expression) => {
+        expect(() => engine.evaluate(expression, {})).toThrowError(
+          'invalid expression'
+        )
+      })
+    })
+
+    test('statement', () => {
+      const exceptions = [
+        { expression: [OPERATOR_EQ] },
+        { expression: [OPERATOR_EQ, 5] },
+        { expression: [OPERATOR_EQ, 5, 5, 5] },
+        { expression: [OPERATOR_NE] },
+        { expression: [OPERATOR_GT] },
+        { expression: [OPERATOR_GE] },
+        { expression: [OPERATOR_LT] },
+        { expression: [OPERATOR_LE] },
+        { expression: [OPERATOR_IN] },
+        { expression: [OPERATOR_NOT_IN] },
+        { expression: [OPERATOR_PREFIX] },
+        { expression: [OPERATOR_SUFFIX] },
+        { expression: [OPERATOR_AND] },
+        { expression: [OPERATOR_OR] },
+        { expression: [OPERATOR_NOR] },
+        { expression: [OPERATOR_XOR] },
+      ]
+
+      for (const exception of exceptions) {
+        // @ts-ignore
+        expect(() => engine.statement(exception.expression)).toThrowError()
+      }
+    })
+
+    describe('parse', () => {
+      test.each([
+        // Operators with invalid operands
+        [[OPERATOR_EQ]],
+        [[OPERATOR_EQ, 5]],
+        [[OPERATOR_EQ, 5, 5, 5]],
+        [[OPERATOR_NE]],
+        [[OPERATOR_GT]],
+        [[OPERATOR_GE]],
+        [[OPERATOR_LT]],
+        [[OPERATOR_LE]],
+        [[OPERATOR_IN]],
+        [[OPERATOR_NOT_IN]],
+        [[OPERATOR_PREFIX]],
+        [[OPERATOR_SUFFIX]],
+        [[OPERATOR_AND]],
+        [[OPERATOR_OR]],
+        [[OPERATOR_NOR]],
+        [[OPERATOR_XOR]],
+        [[OPERATOR_SUM]],
+      ])('%p should throw', (expression) => {
+        expect(() => engine.parse(expression as ExpressionInput)).toThrowError()
+      })
+    })
+
+    describe('simplify', () => {
+      test.each<
+        [
+          exp: ExpressionInput,
+          ctx: Context,
+          expected: boolean | Input,
+          strictKeys?: string[],
+          optionalKeys?: string[],
+        ]
+      >([
+        [['==', '$a', '$b'], { a: 10, b: 20 }, false, []],
+        [['==', '$a', '$b'], { a: 10 }, ['==', '$a', '$b'], []],
+        [['==', '$a', '$b'], { a: 10, b: 10 }, true, []],
+        [
+          ['AND', ['==', '$a', '$b'], ['==', '$c', '$d']],
+          { a: 10, b: 10 },
+          ['==', '$c', '$d'],
+          [],
+        ],
+        [
+          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+          { a: 10, b: 10 },
+          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+          [],
+        ],
+        [
+          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+          { a: 10, b: 10 },
+          false,
+          ['e'],
+        ],
+        [
+          ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
+          { a: 10, b: 10 },
+          true,
+          [],
+        ],
+        [
+          ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
+          { a: 10, b: 20 },
+          true,
+          undefined,
+          ['e'],
+        ],
+        [
+          ['OR', ['==', '$a', 10], ['==', '$b', 20], ['==', '$c', 20]],
+          { c: 10 },
+          ['==', '$b', 20],
+          undefined,
+          ['b'],
+        ],
+        [['PRESENT', '$a'], { a: { obj: 'obj' } }, true, undefined, []],
+        [['==', '$a', null], { a: { obj: 'obj' } }, false, undefined, []],
+        [['>', ['+', '$a', 5], 6], { a: 5 }, true],
+        [['>', ['+', '$a', 5], 6], { a: -2 }, false],
+        [['==', ['+', '$a', 1, 1, 1], 4], { a: 1 }, true],
+        [['>', ['-', '$a', 5], 6], { a: 12 }, true],
+        [['>', ['-', '$a', 5], 6], { a: 11 }, false],
+        [['==', ['-', '$a', 1, 1, 1], 0], { a: 3 }, true],
+        [['>', ['*', '$a', 6], 6], { a: 1.1 }, true],
+        [['>', ['*', '$a', 5], 6], { a: 1 }, false],
+        [['==', ['*', '$a', 1, 2, 3], 30], { a: 5 }, true],
+        [['>', ['/', '$a', 6], 6], { a: 42 }, true],
+        [['>', ['/', '$a', 5], 6], { a: 30 }, false],
+        [['==', ['/', '$a', 3, 2, 1], 15], { a: 90 }, true],
+        [['>', ['/', 10, 0], 10000], {}, true], // 10 / 0 = Infinity
+        [['>', 10000, ['/', 10, 0]], {}, false], // 10 / 0 = Infinity
+        [['>', ['/', 0, 0], 10000], {}, false], // 0 / 0 = NaN
+        [
+          ['>', ['/', 10, 0], ['+', '$a', 0]],
+          { b: 0 },
+          ['>', ['/', 10, 0], ['+', '$a', 0]], // Infinity doesn't get simplified to avoid conversion loss
+        ],
+        [
+          ['>', ['/', '$a', 0], ['+', 0, 0]],
+          { b: 0 },
+          ['>', ['/', '$a', 0], 0],
+        ],
+        [
+          ['>', ['+', 0, 0], ['/', '$a', 0]],
+          { b: 0 },
+          ['>', 0, ['/', '$a', 0]],
+        ],
+        [['==', ['+', ['*', 9, 9], 19], 100], {}, true],
+        [['==', ['+', ['*', 9, 9], ['-', ['/', 250, 5], 31]], 100], {}, true],
+        [['AND', ['==', ['+', 1, 1], 2], ['==', ['+', 2, 2], 4]], {}, true],
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          { Ref1: 4 },
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        ],
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          { Ref1: 1 },
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        ],
+      ])(
+        '%p with context %p should be simplified to %p',
+        (
+          exp,
+          ctx,
+          expected,
+          strictKeys = undefined,
+          optionalKeys = undefined
+        ) => {
+          const engine = new Engine()
+          expect(engine.simplify(exp, ctx, strictKeys, optionalKeys)).toEqual(
+            expected
+          )
+        }
+      )
+
+      test.each<[ExpressionInput]>([
+        [['+', 5, 5]],
+        [['-', 5, 5]],
+        [['*', 5, 5]],
+        [['/', 5, 5]],
+        [['+', ['AND', ['==', 1, 1]], 1]],
+        [['AND', ['+', 1, -1], ['+', ['-', 1, 1], 1]]],
+        [['NOT', ['+', 1, 1]]],
+      ])('%p should throw', (expression) => {
+        expect(() => engine.simplify(expression, {})).toThrowError(
+          'invalid expression'
+        )
+      })
+    })
+
+    describe('unsafeSimplify', () => {
+      it.each<
+        [
+          Input,
+          ExpressionInput,
+          Context,
+          string[] | undefined,
+          string[] | undefined,
+        ]
+      >([
+        // LOGICAL
+        // OR
+        [
+          true,
+          ['OR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['OR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+          ['OR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['==', '$Ref1', 1],
+          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {
+            Ref1: 1,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {
+            Ref1: 2,
+          },
+          undefined,
+          undefined,
+        ],
+        // AND
+        [
+          false,
+          ['AND', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['AND', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+          ['AND', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['==', '$Ref1', 1],
+          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+          {
+            Ref1: 1,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+          {
+            Ref1: 2,
+          },
+          undefined,
+          undefined,
+        ],
+        // NOR
+        [
+          ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+          ['NOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['NOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT', ['==', '$Ref1', 1]],
+          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {
+            Ref1: 2,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+          {
+            Ref1: 1,
+          },
+          undefined,
+          undefined,
+        ],
+        // XOR
+        [
+          true,
+          ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
+          {
+            Ref1: 2,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
+          {
+            Ref1: 3,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT', ['==', '$Ref1', 1]],
+          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 2]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['==', '$Ref1', 1],
+          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 3]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['XOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+          ['XOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [false, ['XOR', ['==', 1, 1], ['==', 2, 2]], {}, undefined, undefined],
+        // NOT
+        [true, ['NOT', ['==', 1, 2]], {}, undefined, undefined],
+        [false, ['NOT', ['==', 1, 1]], {}, undefined, undefined],
+        [false, ['NOT', ['==', '$Ref1', 1]], { Ref1: 1 }, undefined, undefined],
+        [
+          ['NOT', ['==', '$Ref1', 1]],
+          ['NOT', ['==', '$Ref1', 1]],
+          {},
+          undefined,
+          undefined,
+        ],
+        // COMPARISON
+        // Eq
+        [true, ['==', 1, 1], {}, undefined, undefined],
+        [false, ['==', 1, 2], {}, undefined, undefined],
+        [true, ['==', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+        [
+          ['==', '$Ref1', '$Ref2'],
+          ['==', '$Ref1', '$Ref2'],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [false, ['==', '$Ref1', [1]], { Ref1: 1 }, undefined, undefined],
+        // NE
+        [false, ['!=', 1, 1], {}, undefined, undefined],
+        [true, ['!=', 1, 2], {}, undefined, undefined],
+        [false, ['!=', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+        [
+          ['!=', '$Ref1', '$Ref2'],
+          ['!=', '$Ref1', '$Ref2'],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['!=', '$Ref1', '$Ref2'],
+          ['!=', '$Ref1', '$Ref2'],
+          { Ref2: 1 },
+          undefined,
+          undefined,
+        ],
+        // GT
+        [true, ['>', 2, 1], {}, undefined, undefined],
+        [false, ['>', 1, 2], {}, undefined, undefined],
+        [['>', '$Ref1', 1], ['>', '$Ref1', 1], {}, undefined, undefined],
+        [['>', 1, '$Ref1'], ['>', 1, '$Ref1'], {}, undefined, undefined],
+        [true, ['>', '$Ref1', 1], { Ref1: 2 }, undefined, undefined],
+        [false, ['>', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+        [
+          false,
+          ['>', '$Ref1', '2000-01-01'],
+          { Ref1: '1990-01-01' },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['>', '$Ref1', '$Ref2'],
+          { Ref1: 2, Ref2: 1 },
+          undefined,
+          undefined,
+        ],
+        [false, ['>', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+        // GE
+        [true, ['>=', 2, 1], {}, undefined, undefined],
+        [true, ['>=', 2, 2], {}, undefined, undefined],
+        [false, ['>=', 1, 2], {}, undefined, undefined],
+        [['>=', '$Ref1', 2], ['>=', '$Ref1', 2], {}, undefined, undefined],
+        [['>=', 2, '$Ref1'], ['>=', 2, '$Ref1'], {}, undefined, undefined],
+        [
+          true,
+          ['>=', '$Ref1', '2000-01-01'],
+          { Ref1: '2000-01-01' },
+          undefined,
+          undefined,
+        ],
+        [false, ['>=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+        // LT
+        [true, ['<', 1, 2], {}, undefined, undefined],
+        [false, ['<', 2, 1], {}, undefined, undefined],
+        [true, ['<', 1, '$Ref1'], { Ref1: 2 }, undefined, undefined],
+        [false, ['<', 1, '$Ref1'], { Ref1: 1 }, undefined, undefined],
+        [['<', '$Ref1', 2], ['<', '$Ref1', 2], {}, undefined, undefined],
+        [['<', 2, '$Ref1'], ['<', 2, '$Ref1'], {}, undefined, undefined],
+        [
+          false,
+          ['<', '$Ref1', '1990-01-01'],
+          { Ref1: '2000-01-01' },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['<', '$Ref1', '$Ref2'],
+          { Ref1: 1, Ref2: 2 },
+          undefined,
+          undefined,
+        ],
+        [false, ['<', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+        // LE
+        [true, ['<=', 1, 2], {}, undefined, undefined],
+        [true, ['<=', 2, 2], {}, undefined, undefined],
+        [false, ['<=', 2, 1], {}, undefined, undefined],
+        [['<=', '$Ref1', 2], ['<=', '$Ref1', 2], {}, undefined, undefined],
+        [['<=', 2, '$Ref1'], ['<=', 2, '$Ref1'], {}, undefined, undefined],
+        [
+          false,
+          ['<=', '$Ref1', '1990-01-01'],
+          { Ref1: '2000-01-01' },
+          undefined,
+          undefined,
+        ],
+        [false, ['<=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+        // IN
+        [true, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 1 }, undefined, undefined],
+        [false, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
+        [true, ['IN', [1, 2, 3], '$Ref1'], { Ref1: 1 }, undefined, undefined],
+        [
+          ['IN', [1, 2, 3], '$Ref1'],
+          ['IN', [1, 2, 3], '$Ref1'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', '$Ref1', [1, 2, 3]],
+          ['IN', '$Ref1', [1, 2, 3]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+          ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', '$Ref1', [1, 2, 3]],
+          ['OR', ['==', 1, 2], ['IN', '$Ref1', [1, 2, 3]]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', '$Ref1', [1, 2, 3]],
+          ['AND', ['==', 1, 1], ['IN', '$Ref1', [1, 2, 3]]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [false, ['IN', null, [1, 2, 3]], {}, undefined, undefined],
+        [
+          true,
+          ['IN', 1, '$Ref1'],
+          { Ref1: [1, undefined, 3] },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['IN', '$Ref1', 1],
+          { Ref1: [1, undefined, 3] },
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', '$Ref1', '$Ref2'],
+          ['IN', '$Ref1', '$Ref2'],
+          { Ref1: [1, undefined, 3] },
+          undefined,
+          undefined,
+        ],
+        [
+          ['IN', '$Ref1', '$Ref2'],
+          ['IN', '$Ref1', '$Ref2'],
+          { Ref2: [1, undefined, 3] },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['IN', '$Ref1', '$Ref2'],
+          { Ref1: [1, undefined, 3] },
+          ['Ref1', 'Ref2'],
+          undefined,
+        ],
+        [
+          true,
+          ['IN', '$Ref1', '$Ref2'],
+          { Ref1: [1, undefined, 3], Ref2: 1 },
+          ['Ref1', 'Ref2'],
+          undefined,
+        ],
+        [
+          false,
+          ['IN', '$Ref1', '$Ref2'],
+          { Ref1: 1, Ref2: null },
+          undefined,
+          undefined,
+        ],
+        [false, ['IN', '$Ref1', '$Ref2'], { Ref1: 1 }, ['Ref2'], undefined],
+        // NOT_IN
+        [
+          false,
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          { Ref1: 4 },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['NOT IN', [1, 2, 3], '$Ref1'],
+          { Ref1: 4 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+          ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          ['OR', ['==', 1, 2], ['NOT IN', '$Ref1', [1, 2, 3]]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['NOT IN', '$Ref1', [1, 2, 3]],
+          ['AND', ['==', 1, 1], ['NOT IN', '$Ref1', [1, 2, 3]]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [true, ['NOT IN', null, [1, 2, 3]], {}, undefined, undefined],
+        [
+          ['NOT IN', [1, 2, 3], '$Ref1'],
+          ['NOT IN', [1, 2, 3], '$Ref1'],
+          {},
+          undefined,
+          undefined,
+        ],
+        // PREFIX
+        [
+          true,
+          ['PREFIX', 'abc', '$Ref1'],
+          { Ref1: 'abcdef' },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['PREFIX', 'abc', '$Ref1'],
+          { Ref1: 'ab' },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['PREFIX', 'abc', '$Ref1'],
+          { Ref1: 'xyz' },
+          undefined,
+          undefined,
+        ],
+        [
+          ['PREFIX', '$Ref1', 'abc'],
+          ['PREFIX', '$Ref1', 'abc'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['PREFIX', 'abc', '$Ref1'],
+          ['PREFIX', 'abc', '$Ref1'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['PREFIX', 1, '$Ref1'],
+          { Ref1: 'abcdef' },
+          undefined,
+          undefined,
+        ],
+        // SUFFIX
+        [
+          true,
+          ['SUFFIX', '$Ref1', 'xyz'],
+          { Ref1: 'abcdefxyz' },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['SUFFIX', '$Ref1', 'xyz'],
+          { Ref1: 'yz' },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['SUFFIX', '$Ref1', 'xyz'],
+          { Ref1: 'abc' },
+          undefined,
+          undefined,
+        ],
+        [
+          ['SUFFIX', 'xyz', '$Ref1'],
+          ['SUFFIX', 'xyz', '$Ref1'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['SUFFIX', '$Ref1', 'xyz'],
+          ['SUFFIX', '$Ref1', 'xyz'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['SUFFIX', 1, '$Ref1'],
+          { Ref1: 'abcdef' },
+          undefined,
+          undefined,
+        ],
         // OVERLAP
-        ...[
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          {},
+          undefined,
+          undefined,
+        ],
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          {
+            Ref1: 4,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          {
+            Ref1: 1,
+          },
+          ['Ref1', 'Ref2'],
+          undefined,
+        ],
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          {},
+          undefined,
+          ['Ref1', 'Ref2'],
+        ],
+        [
+          true,
+          ['OVERLAP', '$Ref1', [1, 2, 3]],
+          {
+            Ref1: [1],
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+          {},
+          ['Ref1', 'Ref2'],
+          undefined,
+        ],
+        [false, ['OVERLAP', [1, 2, 3], '$Ref1'], {}, ['Ref1'], undefined],
+        [
+          ['OVERLAP', [1, 2, 3], '$Ref1'],
+          ['OVERLAP', [1, 2, 3], '$Ref1'],
+          {},
+          undefined,
+          ['Ref1'],
+        ],
+        [
+          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+          {
+            Ref1: 4,
+          },
+          undefined,
+          undefined,
+        ],
+        [
           [
             'OVERLAP',
-            ['$State1', '$State2', '$State3', '$State4'],
-            ['TX', 'CA'],
-          ],
-        ].map((expression) => [
-          [expression, { State1: 'TX' }, true],
-          [expression, { State1: 'AL' }, false],
-          [
-            expression,
-            { State1: 'TX', State2: 'AL', State3: 'CA', State4: 'CO' },
-            true,
+            ['$Location1Address.region', '$Location2Address.region'],
+            ['DE', 'PA'],
           ],
           [
-            expression,
-            { State1: 'MI', State2: 'RI', State3: 'NY', State4: 'NY' },
-            false,
+            'OVERLAP',
+            ['$Location1Address.region', '$Location2Address.region'],
+            ['DE', 'PA'],
           ],
-        ]),
+          {
+            Location1Address: {
+              street: '633 E Lake Ave',
+              city: 'Peoria',
+              region: 'IL',
+              postalCode: '61614',
+              county: '',
+              country: 'US',
+              secondary: '',
+            },
+            Location1Wc1Code: {
+              code: '9102-2',
+              industry: '',
+            },
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          [
+            'OR',
+            [
+              'AND',
+              [
+                'OVERLAP',
+                ['$Location1Address.region', '$Location2Address.region'],
+                ['DE', 'PA'],
+              ],
+              [
+                'OVERLAP',
+                ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
+                ['0936-2'],
+              ],
+            ],
+            [
+              'AND',
+              [
+                'OVERLAP',
+                ['$Location1Address.region', '$Location2Address.region'],
+                ['AK', 'IL'],
+              ],
+              [
+                'OVERLAP',
+                ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
+                ['7610-3'],
+              ],
+            ],
+          ],
+          {
+            Location1Address: {
+              street: '633 E Lake Ave',
+              city: 'Peoria',
+              region: 'IL',
+              postalCode: '61614',
+              county: '',
+              country: 'US',
+              secondary: '',
+            },
+            Location1Wc1Code: {
+              code: '9102-2',
+              industry: '',
+            },
+          },
+          [],
+          [],
+        ],
         // UNDEFINED
-        ...[['UNDEFINED', '$Name']].map((expression) => [
-          [expression, { Name: undefined }, true],
-          [expression, { Name: 'David' }, false],
-          [expression, { Name: null }, false],
-        ]),
+        [
+          ['UNDEFINED', '$Ref1'],
+          ['UNDEFINED', '$Ref1'],
+          {},
+          undefined,
+          undefined,
+        ],
+        [true, ['UNDEFINED', '$Ref1'], {}, ['Ref1'], undefined],
+        [
+          ['UNDEFINED', '$Ref1'],
+          ['UNDEFINED', '$Ref1'],
+          {},
+          undefined,
+          ['Ref1'],
+        ],
+        [false, ['UNDEFINED', '$Ref1'], { Ref1: false }, ['Ref1'], undefined],
+        [
+          ['UNDEFINED', '$Ref1'],
+          ['UNDEFINED', '$Ref1'],
+          { Ref1: undefined },
+          undefined,
+          undefined,
+        ],
+        [
+          false,
+          ['UNDEFINED', '$Ref1'],
+          { Ref1: 'value' },
+          undefined,
+          undefined,
+        ],
+        [false, ['UNDEFINED', '$Ref1'], { Ref1: null }, undefined, undefined],
         // PRESENT
-        ...[['PRESENT', '$Name']].map((expression) => [
-          [expression, { Name: undefined }, false],
-          [expression, { Name: 'David' }, true],
-          [expression, { Name: null }, false],
-          [expression, { Name: false }, true],
-          [expression, { Name: { obj: 'obj' } }, true],
-        ]),
-        // NOT UNDEFINED
-        ...[['NOT', ['UNDEFINED', '$Name']]].map((expression) => [
-          [expression, { Name: undefined }, false],
-          [expression, { Name: 'David' }, true],
-          [expression, { Name: null }, true],
-        ]),
-        // NOT OVERLAP
-        ...[
-          [
-            'NOT',
-            [
-              'OVERLAP',
-              ['$region1', '$region2'],
-              ['FL', 'LA', 'NY', 'RI', 'TX'],
-            ],
-          ],
-        ].map((expression) => [
-          [expression, { region1: 'FL', region2: 'MI' }, false],
-          [expression, { region1: 'AL', region2: 'MI' }, true],
-        ]),
-      ].flat() as [ExpressionInput, Context, boolean][]
-    )('%p in %p should evaluate as %p', (expression, context, expected) => {
-      expect(engine.evaluate(expression, context)).toEqual(expected)
-    })
-
-    test.each<[ExpressionInput, Context, boolean]>([
-      [['==', ['+', 5, 5, 5], 15], {}, true],
-      [['==', ['+', '$RefA', 5], 15], {}, false],
-      [['==', ['+', '$RefA', 5], 15], { RefA: 10 }, true],
-      [['==', ['+', '$RefA', 5], 15], { RefA: 0 }, false],
-      [['>', ['-', '$RefA', 5], 15], {}, false],
-      [['>', '$RefA', 15], {}, false],
-      [['IN', '$RefA', ['option1', 'option2']], {}, false],
-      [['OVERLAP', ['$RefA', '$RefB'], ['option1', 'option2']], {}, false],
-      [['PRESENT', '$RefA'], {}, false],
-      [['UNDEFINED', '$RefA'], {}, true],
-      [
-        ['AND', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']],
-        { RefB: 'present' },
-        true,
-      ],
-      [['OR', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']], {}, true],
-    ])('%p should evaluate to %p', (expression, context, expectedResult) => {
-      expect(engine.evaluate(expression, context)).toEqual(expectedResult)
-    })
-
-    test.each([
-      // Operators with invalid operands
-      [[OPERATOR_EQ]],
-      [[OPERATOR_EQ, 5]],
-      [[OPERATOR_EQ, 5, 5, 5]],
-      [[OPERATOR_NE]],
-      [[OPERATOR_GT]],
-      [[OPERATOR_GE]],
-      [[OPERATOR_LT]],
-      [[OPERATOR_LE]],
-      [[OPERATOR_IN]],
-      [[OPERATOR_NOT_IN]],
-      [[OPERATOR_PREFIX]],
-      [[OPERATOR_SUFFIX]],
-      [[OPERATOR_AND]],
-      [[OPERATOR_OR]],
-      [[OPERATOR_NOR]],
-      [[OPERATOR_XOR]],
-      [[OPERATOR_SUM]],
-      [[OPERATOR_SUM, 5, 5, 5]],
-    ])('%p should throw', (expression) => {
-      expect(() =>
-        engine.evaluate(expression as ExpressionInput, {})
-      ).toThrowError()
-    })
-
-    test.each<[ExpressionInput]>([
-      [['+', 5, 5]],
-      [['-', 5, 5]],
-      [['*', 5, 5]],
-      [['/', 5, 5]],
-    ])('%p should throw', (expression) => {
-      expect(() => engine.evaluate(expression, {})).toThrowError(
-        'invalid expression'
-      )
-    })
-  })
-
-  test('statement', () => {
-    const exceptions = [
-      { expression: [OPERATOR_EQ] },
-      { expression: [OPERATOR_EQ, 5] },
-      { expression: [OPERATOR_EQ, 5, 5, 5] },
-      { expression: [OPERATOR_NE] },
-      { expression: [OPERATOR_GT] },
-      { expression: [OPERATOR_GE] },
-      { expression: [OPERATOR_LT] },
-      { expression: [OPERATOR_LE] },
-      { expression: [OPERATOR_IN] },
-      { expression: [OPERATOR_NOT_IN] },
-      { expression: [OPERATOR_PREFIX] },
-      { expression: [OPERATOR_SUFFIX] },
-      { expression: [OPERATOR_AND] },
-      { expression: [OPERATOR_OR] },
-      { expression: [OPERATOR_NOR] },
-      { expression: [OPERATOR_XOR] },
-    ]
-
-    for (const exception of exceptions) {
-      // @ts-ignore
-      expect(() => engine.statement(exception.expression)).toThrowError()
-    }
-  })
-
-  describe('parse', () => {
-    test.each([
-      // Operators with invalid operands
-      [[OPERATOR_EQ]],
-      [[OPERATOR_EQ, 5]],
-      [[OPERATOR_EQ, 5, 5, 5]],
-      [[OPERATOR_NE]],
-      [[OPERATOR_GT]],
-      [[OPERATOR_GE]],
-      [[OPERATOR_LT]],
-      [[OPERATOR_LE]],
-      [[OPERATOR_IN]],
-      [[OPERATOR_NOT_IN]],
-      [[OPERATOR_PREFIX]],
-      [[OPERATOR_SUFFIX]],
-      [[OPERATOR_AND]],
-      [[OPERATOR_OR]],
-      [[OPERATOR_NOR]],
-      [[OPERATOR_XOR]],
-      [[OPERATOR_SUM]],
-    ])('%p should throw', (expression) => {
-      expect(() => engine.parse(expression as ExpressionInput)).toThrowError()
-    })
-  })
-
-  describe('simplify', () => {
-    test.each<
-      [
-        exp: ExpressionInput,
-        ctx: Context,
-        expected: boolean | Input,
-        strictKeys?: string[],
-        optionalKeys?: string[],
-      ]
-    >([
-      [['==', '$a', '$b'], { a: 10, b: 20 }, false, []],
-      [['==', '$a', '$b'], { a: 10 }, ['==', '$a', '$b'], []],
-      [['==', '$a', '$b'], { a: 10, b: 10 }, true, []],
-      [
-        ['AND', ['==', '$a', '$b'], ['==', '$c', '$d']],
-        { a: 10, b: 10 },
-        ['==', '$c', '$d'],
-        [],
-      ],
-      [
-        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-        { a: 10, b: 10 },
-        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-        [],
-      ],
-      [
-        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-        { a: 10, b: 10 },
-        false,
-        ['e'],
-      ],
-      [
-        ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
-        { a: 10, b: 10 },
-        true,
-        [],
-      ],
-      [
-        ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
-        { a: 10, b: 20 },
-        true,
-        undefined,
-        ['e'],
-      ],
-      [
-        ['OR', ['==', '$a', 10], ['==', '$b', 20], ['==', '$c', 20]],
-        { c: 10 },
-        ['==', '$b', 20],
-        undefined,
-        ['b'],
-      ],
-      [['PRESENT', '$a'], { a: { obj: 'obj' } }, true, undefined, []],
-      [['==', '$a', null], { a: { obj: 'obj' } }, false, undefined, []],
-      [['>', ['+', '$a', 5], 6], { a: 5 }, true],
-      [['>', ['+', '$a', 5], 6], { a: -2 }, false],
-      [['==', ['+', '$a', 1, 1, 1], 4], { a: 1 }, true],
-      [['>', ['-', '$a', 5], 6], { a: 12 }, true],
-      [['>', ['-', '$a', 5], 6], { a: 11 }, false],
-      [['==', ['-', '$a', 1, 1, 1], 0], { a: 3 }, true],
-      [['>', ['*', '$a', 6], 6], { a: 1.1 }, true],
-      [['>', ['*', '$a', 5], 6], { a: 1 }, false],
-      [['==', ['*', '$a', 1, 2, 3], 30], { a: 5 }, true],
-      [['>', ['/', '$a', 6], 6], { a: 42 }, true],
-      [['>', ['/', '$a', 5], 6], { a: 30 }, false],
-      [['==', ['/', '$a', 3, 2, 1], 15], { a: 90 }, true],
-      [['>', ['/', 10, 0], 10000], {}, true], // 10 / 0 = Infinity
-      [['>', 10000, ['/', 10, 0]], {}, false], // 10 / 0 = Infinity
-      [['>', ['/', 0, 0], 10000], {}, false], // 0 / 0 = NaN
-      [
-        ['>', ['/', 10, 0], ['+', '$a', 0]],
-        { b: 0 },
-        ['>', ['/', 10, 0], ['+', '$a', 0]], // Infinity doesn't get simplified to avoid conversion loss
-      ],
-      [['>', ['/', '$a', 0], ['+', 0, 0]], { b: 0 }, ['>', ['/', '$a', 0], 0]],
-      [['>', ['+', 0, 0], ['/', '$a', 0]], { b: 0 }, ['>', 0, ['/', '$a', 0]]],
-      [['==', ['+', ['*', 9, 9], 19], 100], {}, true],
-      [['==', ['+', ['*', 9, 9], ['-', ['/', 250, 5], 31]], 100], {}, true],
-      [['AND', ['==', ['+', 1, 1], 2], ['==', ['+', 2, 2], 4]], {}, true],
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        { Ref1: 4 },
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-      ],
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        { Ref1: 1 },
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-      ],
-    ])(
-      '%p with context %p should be simplified to %p',
-      (
-        exp,
-        ctx,
-        expected,
-        strictKeys = undefined,
-        optionalKeys = undefined
-      ) => {
-        const engine = new Engine()
-        expect(engine.simplify(exp, ctx, strictKeys, optionalKeys)).toEqual(
-          expected
-        )
-      }
-    )
-
-    test.each<[ExpressionInput]>([
-      [['+', 5, 5]],
-      [['-', 5, 5]],
-      [['*', 5, 5]],
-      [['/', 5, 5]],
-      [['+', ['AND', ['==', 1, 1]], 1]],
-      [['AND', ['+', 1, -1], ['+', ['-', 1, 1], 1]]],
-      [['NOT', ['+', 1, 1]]],
-    ])('%p should throw', (expression) => {
-      expect(() => engine.simplify(expression, {})).toThrowError(
-        'invalid expression'
-      )
-    })
-  })
-
-  describe('unsafeSimplify', () => {
-    it.each<
-      [
-        Input,
-        ExpressionInput,
-        Context,
-        string[] | undefined,
-        string[] | undefined,
-      ]
-    >([
-      // LOGICAL
-      // OR
-      [
-        true,
-        ['OR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['OR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-        ['OR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['==', '$Ref1', 1],
-        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {
-          Ref1: 1,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {
-          Ref1: 2,
-        },
-        undefined,
-        undefined,
-      ],
-      // AND
-      [
-        false,
-        ['AND', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['AND', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-        ['AND', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['==', '$Ref1', 1],
-        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-        {
-          Ref1: 1,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-        {
-          Ref1: 2,
-        },
-        undefined,
-        undefined,
-      ],
-      // NOR
-      [
-        ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-        ['NOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['NOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT', ['==', '$Ref1', 1]],
-        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {
-          Ref1: 2,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-        {
-          Ref1: 1,
-        },
-        undefined,
-        undefined,
-      ],
-      // XOR
-      [
-        true,
-        ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
-        {
-          Ref1: 2,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
-        {
-          Ref1: 3,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT', ['==', '$Ref1', 1]],
-        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 2]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['==', '$Ref1', 1],
-        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 3]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['XOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-        ['XOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [false, ['XOR', ['==', 1, 1], ['==', 2, 2]], {}, undefined, undefined],
-      // NOT
-      [true, ['NOT', ['==', 1, 2]], {}, undefined, undefined],
-      [false, ['NOT', ['==', 1, 1]], {}, undefined, undefined],
-      [false, ['NOT', ['==', '$Ref1', 1]], { Ref1: 1 }, undefined, undefined],
-      [
-        ['NOT', ['==', '$Ref1', 1]],
-        ['NOT', ['==', '$Ref1', 1]],
-        {},
-        undefined,
-        undefined,
-      ],
-      // COMPARISON
-      // Eq
-      [true, ['==', 1, 1], {}, undefined, undefined],
-      [false, ['==', 1, 2], {}, undefined, undefined],
-      [true, ['==', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-      [
-        ['==', '$Ref1', '$Ref2'],
-        ['==', '$Ref1', '$Ref2'],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [false, ['==', '$Ref1', [1]], { Ref1: 1 }, undefined, undefined],
-      // NE
-      [false, ['!=', 1, 1], {}, undefined, undefined],
-      [true, ['!=', 1, 2], {}, undefined, undefined],
-      [false, ['!=', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-      [
-        ['!=', '$Ref1', '$Ref2'],
-        ['!=', '$Ref1', '$Ref2'],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['!=', '$Ref1', '$Ref2'],
-        ['!=', '$Ref1', '$Ref2'],
-        { Ref2: 1 },
-        undefined,
-        undefined,
-      ],
-      // GT
-      [true, ['>', 2, 1], {}, undefined, undefined],
-      [false, ['>', 1, 2], {}, undefined, undefined],
-      [['>', '$Ref1', 1], ['>', '$Ref1', 1], {}, undefined, undefined],
-      [['>', 1, '$Ref1'], ['>', 1, '$Ref1'], {}, undefined, undefined],
-      [true, ['>', '$Ref1', 1], { Ref1: 2 }, undefined, undefined],
-      [false, ['>', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-      [
-        false,
-        ['>', '$Ref1', '2000-01-01'],
-        { Ref1: '1990-01-01' },
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['>', '$Ref1', '$Ref2'],
-        { Ref1: 2, Ref2: 1 },
-        undefined,
-        undefined,
-      ],
-      [false, ['>', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-      // GE
-      [true, ['>=', 2, 1], {}, undefined, undefined],
-      [true, ['>=', 2, 2], {}, undefined, undefined],
-      [false, ['>=', 1, 2], {}, undefined, undefined],
-      [['>=', '$Ref1', 2], ['>=', '$Ref1', 2], {}, undefined, undefined],
-      [['>=', 2, '$Ref1'], ['>=', 2, '$Ref1'], {}, undefined, undefined],
-      [
-        true,
-        ['>=', '$Ref1', '2000-01-01'],
-        { Ref1: '2000-01-01' },
-        undefined,
-        undefined,
-      ],
-      [false, ['>=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-      // LT
-      [true, ['<', 1, 2], {}, undefined, undefined],
-      [false, ['<', 2, 1], {}, undefined, undefined],
-      [true, ['<', 1, '$Ref1'], { Ref1: 2 }, undefined, undefined],
-      [false, ['<', 1, '$Ref1'], { Ref1: 1 }, undefined, undefined],
-      [['<', '$Ref1', 2], ['<', '$Ref1', 2], {}, undefined, undefined],
-      [['<', 2, '$Ref1'], ['<', 2, '$Ref1'], {}, undefined, undefined],
-      [
-        false,
-        ['<', '$Ref1', '1990-01-01'],
-        { Ref1: '2000-01-01' },
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['<', '$Ref1', '$Ref2'],
-        { Ref1: 1, Ref2: 2 },
-        undefined,
-        undefined,
-      ],
-      [false, ['<', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-      // LE
-      [true, ['<=', 1, 2], {}, undefined, undefined],
-      [true, ['<=', 2, 2], {}, undefined, undefined],
-      [false, ['<=', 2, 1], {}, undefined, undefined],
-      [['<=', '$Ref1', 2], ['<=', '$Ref1', 2], {}, undefined, undefined],
-      [['<=', 2, '$Ref1'], ['<=', 2, '$Ref1'], {}, undefined, undefined],
-      [
-        false,
-        ['<=', '$Ref1', '1990-01-01'],
-        { Ref1: '2000-01-01' },
-        undefined,
-        undefined,
-      ],
-      [false, ['<=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-      // IN
-      [true, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 1 }, undefined, undefined],
-      [false, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
-      [true, ['IN', [1, 2, 3], '$Ref1'], { Ref1: 1 }, undefined, undefined],
-      [
-        ['IN', [1, 2, 3], '$Ref1'],
-        ['IN', [1, 2, 3], '$Ref1'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', '$Ref1', [1, 2, 3]],
-        ['IN', '$Ref1', [1, 2, 3]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-        ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', '$Ref1', [1, 2, 3]],
-        ['OR', ['==', 1, 2], ['IN', '$Ref1', [1, 2, 3]]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', '$Ref1', [1, 2, 3]],
-        ['AND', ['==', 1, 1], ['IN', '$Ref1', [1, 2, 3]]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [false, ['IN', null, [1, 2, 3]], {}, undefined, undefined],
-      [
-        true,
-        ['IN', 1, '$Ref1'],
-        { Ref1: [1, undefined, 3] },
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['IN', '$Ref1', 1],
-        { Ref1: [1, undefined, 3] },
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', '$Ref1', '$Ref2'],
-        ['IN', '$Ref1', '$Ref2'],
-        { Ref1: [1, undefined, 3] },
-        undefined,
-        undefined,
-      ],
-      [
-        ['IN', '$Ref1', '$Ref2'],
-        ['IN', '$Ref1', '$Ref2'],
-        { Ref2: [1, undefined, 3] },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['IN', '$Ref1', '$Ref2'],
-        { Ref1: [1, undefined, 3] },
-        ['Ref1', 'Ref2'],
-        undefined,
-      ],
-      [
-        true,
-        ['IN', '$Ref1', '$Ref2'],
-        { Ref1: [1, undefined, 3], Ref2: 1 },
-        ['Ref1', 'Ref2'],
-        undefined,
-      ],
-      [
-        false,
-        ['IN', '$Ref1', '$Ref2'],
-        { Ref1: 1, Ref2: null },
-        undefined,
-        undefined,
-      ],
-      [false, ['IN', '$Ref1', '$Ref2'], { Ref1: 1 }, ['Ref2'], undefined],
-      // NOT_IN
-      [
-        false,
-        ['NOT IN', '$Ref1', [1, 2, 3]],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [true, ['NOT IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
-      [true, ['NOT IN', [1, 2, 3], '$Ref1'], { Ref1: 4 }, undefined, undefined],
-      [
-        ['NOT IN', '$Ref1', [1, 2, 3]],
-        ['NOT IN', '$Ref1', [1, 2, 3]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-        ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT IN', '$Ref1', [1, 2, 3]],
-        ['OR', ['==', 1, 2], ['NOT IN', '$Ref1', [1, 2, 3]]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['NOT IN', '$Ref1', [1, 2, 3]],
-        ['AND', ['==', 1, 1], ['NOT IN', '$Ref1', [1, 2, 3]]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [true, ['NOT IN', null, [1, 2, 3]], {}, undefined, undefined],
-      [
-        ['NOT IN', [1, 2, 3], '$Ref1'],
-        ['NOT IN', [1, 2, 3], '$Ref1'],
-        {},
-        undefined,
-        undefined,
-      ],
-      // PREFIX
-      [
-        true,
-        ['PREFIX', 'abc', '$Ref1'],
-        { Ref1: 'abcdef' },
-        undefined,
-        undefined,
-      ],
-      [false, ['PREFIX', 'abc', '$Ref1'], { Ref1: 'ab' }, undefined, undefined],
-      [
-        false,
-        ['PREFIX', 'abc', '$Ref1'],
-        { Ref1: 'xyz' },
-        undefined,
-        undefined,
-      ],
-      [
-        ['PREFIX', '$Ref1', 'abc'],
-        ['PREFIX', '$Ref1', 'abc'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['PREFIX', 'abc', '$Ref1'],
-        ['PREFIX', 'abc', '$Ref1'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [false, ['PREFIX', 1, '$Ref1'], { Ref1: 'abcdef' }, undefined, undefined],
-      // SUFFIX
-      [
-        true,
-        ['SUFFIX', '$Ref1', 'xyz'],
-        { Ref1: 'abcdefxyz' },
-        undefined,
-        undefined,
-      ],
-      [false, ['SUFFIX', '$Ref1', 'xyz'], { Ref1: 'yz' }, undefined, undefined],
-      [
-        false,
-        ['SUFFIX', '$Ref1', 'xyz'],
-        { Ref1: 'abc' },
-        undefined,
-        undefined,
-      ],
-      [
-        ['SUFFIX', 'xyz', '$Ref1'],
-        ['SUFFIX', 'xyz', '$Ref1'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['SUFFIX', '$Ref1', 'xyz'],
-        ['SUFFIX', '$Ref1', 'xyz'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [false, ['SUFFIX', 1, '$Ref1'], { Ref1: 'abcdef' }, undefined, undefined],
-      // OVERLAP
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        {},
-        undefined,
-        undefined,
-      ],
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        {
-          Ref1: 4,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        true,
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        {
-          Ref1: 1,
-        },
-        ['Ref1', 'Ref2'],
-        undefined,
-      ],
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        {},
-        undefined,
-        ['Ref1', 'Ref2'],
-      ],
-      [
-        true,
-        ['OVERLAP', '$Ref1', [1, 2, 3]],
-        {
-          Ref1: [1],
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
-        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-        {},
-        ['Ref1', 'Ref2'],
-        undefined,
-      ],
-      [false, ['OVERLAP', [1, 2, 3], '$Ref1'], {}, ['Ref1'], undefined],
-      [
-        ['OVERLAP', [1, 2, 3], '$Ref1'],
-        ['OVERLAP', [1, 2, 3], '$Ref1'],
-        {},
-        undefined,
-        ['Ref1'],
-      ],
-      [
-        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-        {
-          Ref1: 4,
-        },
-        undefined,
-        undefined,
-      ],
-      [
         [
-          'OVERLAP',
-          ['$Location1Address.region', '$Location2Address.region'],
-          ['DE', 'PA'],
+          ['PRESENT', '$Ref1'],
+          ['PRESENT', '$Ref1'],
+          { Ref1: undefined },
+          undefined,
+          undefined,
+        ],
+        [true, ['PRESENT', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
+        [false, ['PRESENT', '$Ref1'], { Ref1: null }, undefined, undefined],
+        [true, ['PRESENT', '$Ref1'], { Ref1: false }, undefined, undefined],
+        [false, ['PRESENT', '$Ref1'], {}, ['Ref1'], undefined],
+        [
+          true,
+          ['PRESENT', '$Ref1'],
+          { Ref1: { obj: 'obj' } },
+          undefined,
+          undefined,
+        ],
+        // ARITHMETIC
+        // SUM
+        [true, ['>', ['+', 1, 2, 3], 5], {}, undefined, undefined],
+        [
+          true,
+          ['>', ['+', '$Ref1', '$Ref2'], 2],
+          { Ref1: 1, Ref2: 2 },
+          undefined,
+          undefined,
         ],
         [
-          'OVERLAP',
-          ['$Location1Address.region', '$Location2Address.region'],
-          ['DE', 'PA'],
+          ['>', ['+', '$Ref1', '$Ref2'], 0],
+          ['>', ['+', '$Ref1', '$Ref2'], 0],
+          { Ref1: 1 },
+          undefined,
+          undefined,
         ],
-        {
-          Location1Address: {
-            street: '633 E Lake Ave',
-            city: 'Peoria',
-            region: 'IL',
-            postalCode: '61614',
-            county: '',
-            country: 'US',
-            secondary: '',
-          },
-          Location1Wc1Code: {
-            code: '9102-2',
-            industry: '',
-          },
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        false,
         [
-          'OR',
+          ['>', ['+', '$Ref1', '$Ref2'], 3],
+          ['>', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['>=', ['+', '$Ref1', '$Ref2'], 3],
+          ['>=', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['<', ['+', '$Ref1', '$Ref2'], 0],
+          ['<', ['+', '$Ref1', '$Ref2'], 0],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['<=', ['+', '$Ref1', '$Ref2'], 0],
+          ['<=', ['+', '$Ref1', '$Ref2'], 0],
+          { Ref1: 1 },
+          undefined,
+          undefined,
+        ],
+        [
+          true,
+          ['>', ['+', '$Ref1', 5], 10],
+          { Ref1: 10 },
+          undefined,
+          undefined,
+        ],
+        [true, ['<', ['+', '$Ref1', 5], 10], { Ref1: 0 }, undefined, undefined],
+        [
+          true,
+          ['<', ['+', '$Ref1', 5], 0],
+          { Ref1: -10 },
+          undefined,
+          undefined,
+        ],
+        [false, ['>', ['+', null, null], 5], {}, undefined, undefined],
+        [
+          false,
           [
             'AND',
             [
-              'OVERLAP',
-              ['$Location1Address.region', '$Location2Address.region'],
-              ['DE', 'PA'],
+              '>',
+              [
+                '+',
+                '$Location2Wc1NumberOfFullTimeEmployees',
+                '$Location2Wc1NumberOfPartTimeEmployees',
+              ],
+              99,
             ],
-            [
-              'OVERLAP',
-              ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
-              ['0936-2'],
-            ],
+            ['>=', '$NumberOfLocations', 2],
+          ],
+          { NumberOfLocations: 1 },
+          [
+            'Location2Wc1NumberOfFullTimeEmployees',
+            'Location2Wc1NumberOfPartTimeEmployees',
           ],
           [
-            'AND',
-            [
-              'OVERLAP',
-              ['$Location1Address.region', '$Location2Address.region'],
-              ['AK', 'IL'],
-            ],
-            [
-              'OVERLAP',
-              ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
-              ['7610-3'],
-            ],
+            'Location2Wc1NumberOfFullTimeEmployees',
+            'Location2Wc1NumberOfPartTimeEmployees',
           ],
         ],
-        {
-          Location1Address: {
-            street: '633 E Lake Ave',
-            city: 'Peoria',
-            region: 'IL',
-            postalCode: '61614',
-            county: '',
-            country: 'US',
-            secondary: '',
-          },
-          Location1Wc1Code: {
-            code: '9102-2',
-            industry: '',
-          },
-        },
-        [],
-        [],
-      ],
-      // UNDEFINED
-      [
-        ['UNDEFINED', '$Ref1'],
-        ['UNDEFINED', '$Ref1'],
-        {},
-        undefined,
-        undefined,
-      ],
-      [true, ['UNDEFINED', '$Ref1'], {}, ['Ref1'], undefined],
-      [['UNDEFINED', '$Ref1'], ['UNDEFINED', '$Ref1'], {}, undefined, ['Ref1']],
-      [false, ['UNDEFINED', '$Ref1'], { Ref1: false }, ['Ref1'], undefined],
-      [
-        ['UNDEFINED', '$Ref1'],
-        ['UNDEFINED', '$Ref1'],
-        { Ref1: undefined },
-        undefined,
-        undefined,
-      ],
-      [false, ['UNDEFINED', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
-      [false, ['UNDEFINED', '$Ref1'], { Ref1: null }, undefined, undefined],
-      // PRESENT
-      [
-        ['PRESENT', '$Ref1'],
-        ['PRESENT', '$Ref1'],
-        { Ref1: undefined },
-        undefined,
-        undefined,
-      ],
-      [true, ['PRESENT', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
-      [false, ['PRESENT', '$Ref1'], { Ref1: null }, undefined, undefined],
-      [true, ['PRESENT', '$Ref1'], { Ref1: false }, undefined, undefined],
-      [false, ['PRESENT', '$Ref1'], {}, ['Ref1'], undefined],
-      [
-        true,
-        ['PRESENT', '$Ref1'],
-        { Ref1: { obj: 'obj' } },
-        undefined,
-        undefined,
-      ],
-      // ARITHMETIC
-      // SUM
-      [true, ['>', ['+', 1, 2, 3], 5], {}, undefined, undefined],
-      [
-        true,
-        ['>', ['+', '$Ref1', '$Ref2'], 2],
-        { Ref1: 1, Ref2: 2 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>', ['+', '$Ref1', '$Ref2'], 0],
-        ['>', ['+', '$Ref1', '$Ref2'], 0],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>', ['+', '$Ref1', '$Ref2'], 3],
-        ['>', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>=', ['+', '$Ref1', '$Ref2'], 3],
-        ['>=', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['<', ['+', '$Ref1', '$Ref2'], 0],
-        ['<', ['+', '$Ref1', '$Ref2'], 0],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['<=', ['+', '$Ref1', '$Ref2'], 0],
-        ['<=', ['+', '$Ref1', '$Ref2'], 0],
-        { Ref1: 1 },
-        undefined,
-        undefined,
-      ],
-      [true, ['>', ['+', '$Ref1', 5], 10], { Ref1: 10 }, undefined, undefined],
-      [true, ['<', ['+', '$Ref1', 5], 10], { Ref1: 0 }, undefined, undefined],
-      [true, ['<', ['+', '$Ref1', 5], 0], { Ref1: -10 }, undefined, undefined],
-      [false, ['>', ['+', null, null], 5], {}, undefined, undefined],
-      [
-        false,
+        // SUBTRACT
+        [true, ['>', ['-', 5, 2], 2], {}, undefined, undefined],
         [
-          'AND',
-          [
-            '>',
-            [
-              '+',
-              '$Location2Wc1NumberOfFullTimeEmployees',
-              '$Location2Wc1NumberOfPartTimeEmployees',
-            ],
-            99,
-          ],
-          ['>=', '$NumberOfLocations', 2],
-        ],
-        { NumberOfLocations: 1 },
-        [
-          'Location2Wc1NumberOfFullTimeEmployees',
-          'Location2Wc1NumberOfPartTimeEmployees',
+          true,
+          ['>', ['-', '$Ref1', '$Ref2'], 2],
+          { Ref1: 5, Ref2: 2 },
+          undefined,
+          undefined,
         ],
         [
-          'Location2Wc1NumberOfFullTimeEmployees',
-          'Location2Wc1NumberOfPartTimeEmployees',
+          ['>', ['-', '$Ref1', '$Ref2'], 0],
+          ['>', ['-', '$Ref1', '$Ref2'], 0],
+          { Ref1: 5 },
+          undefined,
+          undefined,
         ],
-      ],
-      // SUBTRACT
-      [true, ['>', ['-', 5, 2], 2], {}, undefined, undefined],
-      [
-        true,
-        ['>', ['-', '$Ref1', '$Ref2'], 2],
-        { Ref1: 5, Ref2: 2 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>', ['-', '$Ref1', '$Ref2'], 0],
-        ['>', ['-', '$Ref1', '$Ref2'], 0],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>', ['-', '$Ref1', '$Ref2'], 3],
-        ['>', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>=', ['-', '$Ref1', '$Ref2'], 3],
-        ['>=', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['<', ['-', '$Ref1', '$Ref2'], 0],
-        ['<', ['-', '$Ref1', '$Ref2'], 0],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['<=', ['-', '$Ref1', '$Ref2'], 0],
-        ['<=', ['-', '$Ref1', '$Ref2'], 0],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [false, ['>', ['-', null, null], 5], {}, undefined, undefined],
-      // MULTIPLY
-      [true, ['>', ['*', 2, 3], 5], {}, undefined, undefined],
-      [
-        true,
-        ['>', ['*', '$Ref1', '$Ref2'], 2],
-        { Ref1: 2, Ref2: 3 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['<', ['*', '$Ref1', '$Ref2'], 0],
-        ['<', ['*', '$Ref1', '$Ref2'], 0],
-        { Ref1: 5 },
-        undefined,
-        undefined,
-      ],
-      [false, ['>', ['*', null, null], 5], {}, undefined, undefined],
-      // DIVIDE
-      [true, ['>=', ['/', 10, 2], 5], {}, undefined, undefined],
-      [
-        true,
-        ['>=', ['/', '$Ref1', '$Ref2'], 2],
-        { Ref1: 10, Ref2: 5 },
-        undefined,
-        undefined,
-      ],
-      [
-        ['>', ['/', '$Ref1', '$Ref2'], 0],
-        ['>', ['/', '$Ref1', '$Ref2'], 0],
-        { Ref1: 10 },
-        undefined,
-        undefined,
-      ],
-      [false, ['>', ['/', null, null], 5], {}, undefined, undefined],
-    ])(
-      'should result in %j',
-      (expectedResult, condition, context, strictKeys, optionalKeys) => {
-        const safeResult = engine.simplify(
-          condition,
-          context,
-          strictKeys,
-          optionalKeys
-        )
-        const unsafeResult = engine.unsafeSimplify(
-          condition,
-          context,
-          strictKeys,
-          optionalKeys
-        )
-        expect(safeResult).toEqual(expectedResult)
-        expect(unsafeResult).toEqual(expectedResult)
-        expect(safeResult).toEqual(unsafeResult)
-      }
-    )
-
-    it.each<
-      [
-        Input,
-        Input,
-        ExpressionInput,
-        Context,
-        string[] | undefined,
-        string[] | undefined,
-      ]
-    >([
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
-        true,
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
-        {
-          Ref1: 1,
-        },
-        undefined,
-        undefined,
-      ],
-      [
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        true,
-        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        {
-          Ref1: 1,
-        },
-        [],
-        ['Ref1', 'Ref2'],
-      ],
-      [
-        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        true,
-        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-        {
-          Ref1: 1,
-        },
-        undefined,
-        undefined,
-      ],
-    ])(
-      'should have different results as %j and %j',
-      (
-        expectedSafeResult,
-        expectedUnsafeResult,
-        condition,
-        context,
-        strictKeys,
-        optionalKeys
-      ) => {
-        const safeResult = engine.simplify(
-          condition,
-          context,
-          strictKeys,
-          optionalKeys
-        )
-        const unsafeResult = engine.unsafeSimplify(
-          condition,
-          context,
-          strictKeys,
-          optionalKeys
-        )
-        expect(safeResult).toEqual(expectedSafeResult)
-        expect(unsafeResult).toEqual(expectedUnsafeResult)
-      }
-    )
-
-    it('should be closer to 100% code coverage', () => {
-      expect(() =>
-        engine.unsafeSimplify(['OR', [1, [1, '$Ref1', 1], 3], ['==', 1, 1]], {})
-      ).toThrow(
-        'Unexpected expression found within a collection of values/references'
+        [
+          ['>', ['-', '$Ref1', '$Ref2'], 3],
+          ['>', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
+          { Ref1: 5 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['>=', ['-', '$Ref1', '$Ref2'], 3],
+          ['>=', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
+          { Ref1: 5 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['<', ['-', '$Ref1', '$Ref2'], 0],
+          ['<', ['-', '$Ref1', '$Ref2'], 0],
+          { Ref1: 5 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['<=', ['-', '$Ref1', '$Ref2'], 0],
+          ['<=', ['-', '$Ref1', '$Ref2'], 0],
+          { Ref1: 5 },
+          undefined,
+          undefined,
+        ],
+        [false, ['>', ['-', null, null], 5], {}, undefined, undefined],
+        // MULTIPLY
+        [true, ['>', ['*', 2, 3], 5], {}, undefined, undefined],
+        [
+          true,
+          ['>', ['*', '$Ref1', '$Ref2'], 2],
+          { Ref1: 2, Ref2: 3 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['<', ['*', '$Ref1', '$Ref2'], 0],
+          ['<', ['*', '$Ref1', '$Ref2'], 0],
+          { Ref1: 5 },
+          undefined,
+          undefined,
+        ],
+        [false, ['>', ['*', null, null], 5], {}, undefined, undefined],
+        // DIVIDE
+        [true, ['>=', ['/', 10, 2], 5], {}, undefined, undefined],
+        [
+          true,
+          ['>=', ['/', '$Ref1', '$Ref2'], 2],
+          { Ref1: 10, Ref2: 5 },
+          undefined,
+          undefined,
+        ],
+        [
+          ['>', ['/', '$Ref1', '$Ref2'], 0],
+          ['>', ['/', '$Ref1', '$Ref2'], 0],
+          { Ref1: 10 },
+          undefined,
+          undefined,
+        ],
+        [false, ['>', ['/', null, null], 5], {}, undefined, undefined],
+      ])(
+        'should result in %j',
+        (expectedResult, condition, context, strictKeys, optionalKeys) => {
+          const safeResult = engine.simplify(
+            condition,
+            context,
+            strictKeys,
+            optionalKeys
+          )
+          const unsafeResult = engine.unsafeSimplify(
+            condition,
+            context,
+            strictKeys,
+            optionalKeys
+          )
+          expect(safeResult).toEqual(expectedResult)
+          expect(unsafeResult).toEqual(expectedResult)
+          expect(safeResult).toEqual(unsafeResult)
+        }
       )
+
+      it.each<
+        [
+          Input,
+          Input,
+          ExpressionInput,
+          Context,
+          string[] | undefined,
+          string[] | undefined,
+        ]
+      >([
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
+          true,
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
+          {
+            Ref1: 1,
+          },
+          undefined,
+          undefined,
+        ],
+        [
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          true,
+          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+          {
+            Ref1: 1,
+          },
+          [],
+          ['Ref1', 'Ref2'],
+        ],
+        [
+          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          true,
+          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+          {
+            Ref1: 1,
+          },
+          undefined,
+          undefined,
+        ],
+      ])(
+        'should have different results as %j and %j',
+        (
+          expectedSafeResult,
+          expectedUnsafeResult,
+          condition,
+          context,
+          strictKeys,
+          optionalKeys
+        ) => {
+          const safeResult = engine.simplify(
+            condition,
+            context,
+            strictKeys,
+            optionalKeys
+          )
+          const unsafeResult = engine.unsafeSimplify(
+            condition,
+            context,
+            strictKeys,
+            optionalKeys
+          )
+          expect(safeResult).toEqual(expectedSafeResult)
+          expect(unsafeResult).toEqual(expectedUnsafeResult)
+        }
+      )
+
+      it('should be closer to 100% code coverage', () => {
+        expect(() =>
+          engine.unsafeSimplify(
+            ['OR', [1, [1, '$Ref1', 1], 3], ['==', 1, 1]],
+            {}
+          )
+        ).toThrow(
+          'Unexpected expression found within a collection of values/references'
+        )
+      })
     })
-  })
-})
+  }
+)

--- a/src/__test__/unit/index.test.ts
+++ b/src/__test__/unit/index.test.ts
@@ -17,1310 +17,1236 @@ import { OPERATOR as OPERATOR_OR } from '../../expression/logical/or'
 import { OPERATOR as OPERATOR_XOR } from '../../expression/logical/xor'
 import { ExpressionInput, Input } from '../../parser'
 
-describe.each([false, true])(
-  'Condition Engine with cache %s',
-  (cacheReferences) => {
-    const engine = new Engine({ cacheReferences })
+describe('Condition Engine', () => {
+  const engine = new Engine()
 
-    describe('evaluate', () => {
-      test.each(
-        [
-          // OVERLAP
-          ...[
+  describe('evaluate', () => {
+    test.each(
+      [
+        // OVERLAP
+        ...[
+          [
+            'OVERLAP',
+            ['$State1', '$State2', '$State3', '$State4'],
+            ['TX', 'CA'],
+          ],
+        ].map((expression) => [
+          [expression, { State1: 'TX' }, true],
+          [expression, { State1: 'AL' }, false],
+          [
+            expression,
+            { State1: 'TX', State2: 'AL', State3: 'CA', State4: 'CO' },
+            true,
+          ],
+          [
+            expression,
+            { State1: 'MI', State2: 'RI', State3: 'NY', State4: 'NY' },
+            false,
+          ],
+        ]),
+        // UNDEFINED
+        ...[['UNDEFINED', '$Name']].map((expression) => [
+          [expression, { Name: undefined }, true],
+          [expression, { Name: 'David' }, false],
+          [expression, { Name: null }, false],
+        ]),
+        // PRESENT
+        ...[['PRESENT', '$Name']].map((expression) => [
+          [expression, { Name: undefined }, false],
+          [expression, { Name: 'David' }, true],
+          [expression, { Name: null }, false],
+          [expression, { Name: false }, true],
+          [expression, { Name: { obj: 'obj' } }, true],
+        ]),
+        // NOT UNDEFINED
+        ...[['NOT', ['UNDEFINED', '$Name']]].map((expression) => [
+          [expression, { Name: undefined }, false],
+          [expression, { Name: 'David' }, true],
+          [expression, { Name: null }, true],
+        ]),
+        // NOT OVERLAP
+        ...[
+          [
+            'NOT',
             [
               'OVERLAP',
-              ['$State1', '$State2', '$State3', '$State4'],
-              ['TX', 'CA'],
+              ['$region1', '$region2'],
+              ['FL', 'LA', 'NY', 'RI', 'TX'],
             ],
-          ].map((expression) => [
-            [expression, { State1: 'TX' }, true],
-            [expression, { State1: 'AL' }, false],
-            [
-              expression,
-              { State1: 'TX', State2: 'AL', State3: 'CA', State4: 'CO' },
-              true,
-            ],
-            [
-              expression,
-              { State1: 'MI', State2: 'RI', State3: 'NY', State4: 'NY' },
-              false,
-            ],
-          ]),
-          // UNDEFINED
-          ...[['UNDEFINED', '$Name']].map((expression) => [
-            [expression, { Name: undefined }, true],
-            [expression, { Name: 'David' }, false],
-            [expression, { Name: null }, false],
-          ]),
-          // PRESENT
-          ...[['PRESENT', '$Name']].map((expression) => [
-            [expression, { Name: undefined }, false],
-            [expression, { Name: 'David' }, true],
-            [expression, { Name: null }, false],
-            [expression, { Name: false }, true],
-            [expression, { Name: { obj: 'obj' } }, true],
-          ]),
-          // NOT UNDEFINED
-          ...[['NOT', ['UNDEFINED', '$Name']]].map((expression) => [
-            [expression, { Name: undefined }, false],
-            [expression, { Name: 'David' }, true],
-            [expression, { Name: null }, true],
-          ]),
-          // NOT OVERLAP
-          ...[
-            [
-              'NOT',
-              [
-                'OVERLAP',
-                ['$region1', '$region2'],
-                ['FL', 'LA', 'NY', 'RI', 'TX'],
-              ],
-            ],
-          ].map((expression) => [
-            [expression, { region1: 'FL', region2: 'MI' }, false],
-            [expression, { region1: 'AL', region2: 'MI' }, true],
-          ]),
-        ].flat() as [ExpressionInput, Context, boolean][]
-      )('%p in %p should evaluate as %p', (expression, context, expected) => {
-        expect(engine.evaluate(expression, context)).toEqual(expected)
-      })
-
-      test.each<[ExpressionInput, Context, boolean]>([
-        [['==', ['+', 5, 5, 5], 15], {}, true],
-        [['==', ['+', '$RefA', 5], 15], {}, false],
-        [['==', ['+', '$RefA', 5], 15], { RefA: 10 }, true],
-        [['==', ['+', '$RefA', 5], 15], { RefA: 0 }, false],
-        [['>', ['-', '$RefA', 5], 15], {}, false],
-        [['>', '$RefA', 15], {}, false],
-        [['IN', '$RefA', ['option1', 'option2']], {}, false],
-        [['OVERLAP', ['$RefA', '$RefB'], ['option1', 'option2']], {}, false],
-        [['PRESENT', '$RefA'], {}, false],
-        [['UNDEFINED', '$RefA'], {}, true],
-        [
-          ['AND', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']],
-          { RefB: 'present' },
-          true,
-        ],
-        [['OR', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']], {}, true],
-      ])('%p should evaluate to %p', (expression, context, expectedResult) => {
-        expect(engine.evaluate(expression, context)).toEqual(expectedResult)
-      })
-
-      test.each([
-        // Operators with invalid operands
-        [[OPERATOR_EQ]],
-        [[OPERATOR_EQ, 5]],
-        [[OPERATOR_EQ, 5, 5, 5]],
-        [[OPERATOR_NE]],
-        [[OPERATOR_GT]],
-        [[OPERATOR_GE]],
-        [[OPERATOR_LT]],
-        [[OPERATOR_LE]],
-        [[OPERATOR_IN]],
-        [[OPERATOR_NOT_IN]],
-        [[OPERATOR_PREFIX]],
-        [[OPERATOR_SUFFIX]],
-        [[OPERATOR_AND]],
-        [[OPERATOR_OR]],
-        [[OPERATOR_NOR]],
-        [[OPERATOR_XOR]],
-        [[OPERATOR_SUM]],
-        [[OPERATOR_SUM, 5, 5, 5]],
-      ])('%p should throw', (expression) => {
-        expect(() =>
-          engine.evaluate(expression as ExpressionInput, {})
-        ).toThrowError()
-      })
-
-      test.each<[ExpressionInput]>([
-        [['+', 5, 5]],
-        [['-', 5, 5]],
-        [['*', 5, 5]],
-        [['/', 5, 5]],
-      ])('%p should throw', (expression) => {
-        expect(() => engine.evaluate(expression, {})).toThrowError(
-          'invalid expression'
-        )
-      })
+          ],
+        ].map((expression) => [
+          [expression, { region1: 'FL', region2: 'MI' }, false],
+          [expression, { region1: 'AL', region2: 'MI' }, true],
+        ]),
+      ].flat() as [ExpressionInput, Context, boolean][]
+    )('%p in %p should evaluate as %p', (expression, context, expected) => {
+      expect(engine.evaluate(expression, context)).toEqual(expected)
     })
 
-    test('statement', () => {
-      const exceptions = [
-        { expression: [OPERATOR_EQ] },
-        { expression: [OPERATOR_EQ, 5] },
-        { expression: [OPERATOR_EQ, 5, 5, 5] },
-        { expression: [OPERATOR_NE] },
-        { expression: [OPERATOR_GT] },
-        { expression: [OPERATOR_GE] },
-        { expression: [OPERATOR_LT] },
-        { expression: [OPERATOR_LE] },
-        { expression: [OPERATOR_IN] },
-        { expression: [OPERATOR_NOT_IN] },
-        { expression: [OPERATOR_PREFIX] },
-        { expression: [OPERATOR_SUFFIX] },
-        { expression: [OPERATOR_AND] },
-        { expression: [OPERATOR_OR] },
-        { expression: [OPERATOR_NOR] },
-        { expression: [OPERATOR_XOR] },
-      ]
-
-      for (const exception of exceptions) {
-        // @ts-ignore
-        expect(() => engine.statement(exception.expression)).toThrowError()
-      }
+    test.each<[ExpressionInput, Context, boolean]>([
+      [['==', ['+', 5, 5, 5], 15], {}, true],
+      [['==', ['+', '$RefA', 5], 15], {}, false],
+      [['==', ['+', '$RefA', 5], 15], { RefA: 10 }, true],
+      [['==', ['+', '$RefA', 5], 15], { RefA: 0 }, false],
+      [['>', ['-', '$RefA', 5], 15], {}, false],
+      [['>', '$RefA', 15], {}, false],
+      [['IN', '$RefA', ['option1', 'option2']], {}, false],
+      [['OVERLAP', ['$RefA', '$RefB'], ['option1', 'option2']], {}, false],
+      [['PRESENT', '$RefA'], {}, false],
+      [['UNDEFINED', '$RefA'], {}, true],
+      [
+        ['AND', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']],
+        { RefB: 'present' },
+        true,
+      ],
+      [['OR', ['UNDEFINED', '$RefA'], ['PRESENT', '$RefB']], {}, true],
+    ])('%p should evaluate to %p', (expression, context, expectedResult) => {
+      expect(engine.evaluate(expression, context)).toEqual(expectedResult)
     })
 
-    describe('parse', () => {
-      test.each([
-        // Operators with invalid operands
-        [[OPERATOR_EQ]],
-        [[OPERATOR_EQ, 5]],
-        [[OPERATOR_EQ, 5, 5, 5]],
-        [[OPERATOR_NE]],
-        [[OPERATOR_GT]],
-        [[OPERATOR_GE]],
-        [[OPERATOR_LT]],
-        [[OPERATOR_LE]],
-        [[OPERATOR_IN]],
-        [[OPERATOR_NOT_IN]],
-        [[OPERATOR_PREFIX]],
-        [[OPERATOR_SUFFIX]],
-        [[OPERATOR_AND]],
-        [[OPERATOR_OR]],
-        [[OPERATOR_NOR]],
-        [[OPERATOR_XOR]],
-        [[OPERATOR_SUM]],
-      ])('%p should throw', (expression) => {
-        expect(() => engine.parse(expression as ExpressionInput)).toThrowError()
-      })
+    test.each([
+      // Operators with invalid operands
+      [[OPERATOR_EQ]],
+      [[OPERATOR_EQ, 5]],
+      [[OPERATOR_EQ, 5, 5, 5]],
+      [[OPERATOR_NE]],
+      [[OPERATOR_GT]],
+      [[OPERATOR_GE]],
+      [[OPERATOR_LT]],
+      [[OPERATOR_LE]],
+      [[OPERATOR_IN]],
+      [[OPERATOR_NOT_IN]],
+      [[OPERATOR_PREFIX]],
+      [[OPERATOR_SUFFIX]],
+      [[OPERATOR_AND]],
+      [[OPERATOR_OR]],
+      [[OPERATOR_NOR]],
+      [[OPERATOR_XOR]],
+      [[OPERATOR_SUM]],
+      [[OPERATOR_SUM, 5, 5, 5]],
+    ])('%p should throw', (expression) => {
+      expect(() =>
+        engine.evaluate(expression as ExpressionInput, {})
+      ).toThrowError()
     })
 
-    describe('simplify', () => {
-      test.each<
-        [
-          exp: ExpressionInput,
-          ctx: Context,
-          expected: boolean | Input,
-          strictKeys?: string[],
-          optionalKeys?: string[],
-        ]
-      >([
-        [['==', '$a', '$b'], { a: 10, b: 20 }, false, []],
-        [['==', '$a', '$b'], { a: 10 }, ['==', '$a', '$b'], []],
-        [['==', '$a', '$b'], { a: 10, b: 10 }, true, []],
-        [
-          ['AND', ['==', '$a', '$b'], ['==', '$c', '$d']],
-          { a: 10, b: 10 },
-          ['==', '$c', '$d'],
-          [],
-        ],
-        [
-          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-          { a: 10, b: 10 },
-          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-          [],
-        ],
-        [
-          ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
-          { a: 10, b: 10 },
-          false,
-          ['e'],
-        ],
-        [
-          ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
-          { a: 10, b: 10 },
-          true,
-          [],
-        ],
-        [
-          ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
-          { a: 10, b: 20 },
-          true,
-          undefined,
-          ['e'],
-        ],
-        [
-          ['OR', ['==', '$a', 10], ['==', '$b', 20], ['==', '$c', 20]],
-          { c: 10 },
-          ['==', '$b', 20],
-          undefined,
-          ['b'],
-        ],
-        [['PRESENT', '$a'], { a: { obj: 'obj' } }, true, undefined, []],
-        [['==', '$a', null], { a: { obj: 'obj' } }, false, undefined, []],
-        [['>', ['+', '$a', 5], 6], { a: 5 }, true],
-        [['>', ['+', '$a', 5], 6], { a: -2 }, false],
-        [['==', ['+', '$a', 1, 1, 1], 4], { a: 1 }, true],
-        [['>', ['-', '$a', 5], 6], { a: 12 }, true],
-        [['>', ['-', '$a', 5], 6], { a: 11 }, false],
-        [['==', ['-', '$a', 1, 1, 1], 0], { a: 3 }, true],
-        [['>', ['*', '$a', 6], 6], { a: 1.1 }, true],
-        [['>', ['*', '$a', 5], 6], { a: 1 }, false],
-        [['==', ['*', '$a', 1, 2, 3], 30], { a: 5 }, true],
-        [['>', ['/', '$a', 6], 6], { a: 42 }, true],
-        [['>', ['/', '$a', 5], 6], { a: 30 }, false],
-        [['==', ['/', '$a', 3, 2, 1], 15], { a: 90 }, true],
-        [['>', ['/', 10, 0], 10000], {}, true], // 10 / 0 = Infinity
-        [['>', 10000, ['/', 10, 0]], {}, false], // 10 / 0 = Infinity
-        [['>', ['/', 0, 0], 10000], {}, false], // 0 / 0 = NaN
-        [
-          ['>', ['/', 10, 0], ['+', '$a', 0]],
-          { b: 0 },
-          ['>', ['/', 10, 0], ['+', '$a', 0]], // Infinity doesn't get simplified to avoid conversion loss
-        ],
-        [
-          ['>', ['/', '$a', 0], ['+', 0, 0]],
-          { b: 0 },
-          ['>', ['/', '$a', 0], 0],
-        ],
-        [
-          ['>', ['+', 0, 0], ['/', '$a', 0]],
-          { b: 0 },
-          ['>', 0, ['/', '$a', 0]],
-        ],
-        [['==', ['+', ['*', 9, 9], 19], 100], {}, true],
-        [['==', ['+', ['*', 9, 9], ['-', ['/', 250, 5], 31]], 100], {}, true],
-        [['AND', ['==', ['+', 1, 1], 2], ['==', ['+', 2, 2], 4]], {}, true],
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          { Ref1: 4 },
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        ],
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          { Ref1: 1 },
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-        ],
-      ])(
-        '%p with context %p should be simplified to %p',
-        (
-          exp,
-          ctx,
-          expected,
-          strictKeys = undefined,
-          optionalKeys = undefined
-        ) => {
-          const engine = new Engine()
-          expect(engine.simplify(exp, ctx, strictKeys, optionalKeys)).toEqual(
-            expected
-          )
-        }
+    test.each<[ExpressionInput]>([
+      [['+', 5, 5]],
+      [['-', 5, 5]],
+      [['*', 5, 5]],
+      [['/', 5, 5]],
+    ])('%p should throw', (expression) => {
+      expect(() => engine.evaluate(expression, {})).toThrowError(
+        'invalid expression'
       )
-
-      test.each<[ExpressionInput]>([
-        [['+', 5, 5]],
-        [['-', 5, 5]],
-        [['*', 5, 5]],
-        [['/', 5, 5]],
-        [['+', ['AND', ['==', 1, 1]], 1]],
-        [['AND', ['+', 1, -1], ['+', ['-', 1, 1], 1]]],
-        [['NOT', ['+', 1, 1]]],
-      ])('%p should throw', (expression) => {
-        expect(() => engine.simplify(expression, {})).toThrowError(
-          'invalid expression'
-        )
-      })
     })
+  })
 
-    describe('unsafeSimplify', () => {
-      it.each<
+  test('statement', () => {
+    const exceptions = [
+      { expression: [OPERATOR_EQ] },
+      { expression: [OPERATOR_EQ, 5] },
+      { expression: [OPERATOR_EQ, 5, 5, 5] },
+      { expression: [OPERATOR_NE] },
+      { expression: [OPERATOR_GT] },
+      { expression: [OPERATOR_GE] },
+      { expression: [OPERATOR_LT] },
+      { expression: [OPERATOR_LE] },
+      { expression: [OPERATOR_IN] },
+      { expression: [OPERATOR_NOT_IN] },
+      { expression: [OPERATOR_PREFIX] },
+      { expression: [OPERATOR_SUFFIX] },
+      { expression: [OPERATOR_AND] },
+      { expression: [OPERATOR_OR] },
+      { expression: [OPERATOR_NOR] },
+      { expression: [OPERATOR_XOR] },
+    ]
+
+    for (const exception of exceptions) {
+      // @ts-ignore
+      expect(() => engine.statement(exception.expression)).toThrowError()
+    }
+  })
+
+  describe('parse', () => {
+    test.each([
+      // Operators with invalid operands
+      [[OPERATOR_EQ]],
+      [[OPERATOR_EQ, 5]],
+      [[OPERATOR_EQ, 5, 5, 5]],
+      [[OPERATOR_NE]],
+      [[OPERATOR_GT]],
+      [[OPERATOR_GE]],
+      [[OPERATOR_LT]],
+      [[OPERATOR_LE]],
+      [[OPERATOR_IN]],
+      [[OPERATOR_NOT_IN]],
+      [[OPERATOR_PREFIX]],
+      [[OPERATOR_SUFFIX]],
+      [[OPERATOR_AND]],
+      [[OPERATOR_OR]],
+      [[OPERATOR_NOR]],
+      [[OPERATOR_XOR]],
+      [[OPERATOR_SUM]],
+    ])('%p should throw', (expression) => {
+      expect(() => engine.parse(expression as ExpressionInput)).toThrowError()
+    })
+  })
+
+  describe('simplify', () => {
+    test.each<
+      [
+        exp: ExpressionInput,
+        ctx: Context,
+        expected: boolean | Input,
+        strictKeys?: string[],
+        optionalKeys?: string[],
+      ]
+    >([
+      [['==', '$a', '$b'], { a: 10, b: 20 }, false, []],
+      [['==', '$a', '$b'], { a: 10 }, ['==', '$a', '$b'], []],
+      [['==', '$a', '$b'], { a: 10, b: 10 }, true, []],
+      [
+        ['AND', ['==', '$a', '$b'], ['==', '$c', '$d']],
+        { a: 10, b: 10 },
+        ['==', '$c', '$d'],
+        [],
+      ],
+      [
+        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+        { a: 10, b: 10 },
+        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+        [],
+      ],
+      [
+        ['AND', ['==', '$a', '$e'], ['==', '$c', '$d']],
+        { a: 10, b: 10 },
+        false,
+        ['e'],
+      ],
+      [
+        ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
+        { a: 10, b: 10 },
+        true,
+        [],
+      ],
+      [
+        ['OR', ['==', '$a', '$b'], ['==', '$c', '$d']],
+        { a: 10, b: 20 },
+        true,
+        undefined,
+        ['e'],
+      ],
+      [
+        ['OR', ['==', '$a', 10], ['==', '$b', 20], ['==', '$c', 20]],
+        { c: 10 },
+        ['==', '$b', 20],
+        undefined,
+        ['b'],
+      ],
+      [['PRESENT', '$a'], { a: { obj: 'obj' } }, true, undefined, []],
+      [['==', '$a', null], { a: { obj: 'obj' } }, false, undefined, []],
+      [['>', ['+', '$a', 5], 6], { a: 5 }, true],
+      [['>', ['+', '$a', 5], 6], { a: -2 }, false],
+      [['==', ['+', '$a', 1, 1, 1], 4], { a: 1 }, true],
+      [['>', ['-', '$a', 5], 6], { a: 12 }, true],
+      [['>', ['-', '$a', 5], 6], { a: 11 }, false],
+      [['==', ['-', '$a', 1, 1, 1], 0], { a: 3 }, true],
+      [['>', ['*', '$a', 6], 6], { a: 1.1 }, true],
+      [['>', ['*', '$a', 5], 6], { a: 1 }, false],
+      [['==', ['*', '$a', 1, 2, 3], 30], { a: 5 }, true],
+      [['>', ['/', '$a', 6], 6], { a: 42 }, true],
+      [['>', ['/', '$a', 5], 6], { a: 30 }, false],
+      [['==', ['/', '$a', 3, 2, 1], 15], { a: 90 }, true],
+      [['>', ['/', 10, 0], 10000], {}, true], // 10 / 0 = Infinity
+      [['>', 10000, ['/', 10, 0]], {}, false], // 10 / 0 = Infinity
+      [['>', ['/', 0, 0], 10000], {}, false], // 0 / 0 = NaN
+      [
+        ['>', ['/', 10, 0], ['+', '$a', 0]],
+        { b: 0 },
+        ['>', ['/', 10, 0], ['+', '$a', 0]], // Infinity doesn't get simplified to avoid conversion loss
+      ],
+      [['>', ['/', '$a', 0], ['+', 0, 0]], { b: 0 }, ['>', ['/', '$a', 0], 0]],
+      [['>', ['+', 0, 0], ['/', '$a', 0]], { b: 0 }, ['>', 0, ['/', '$a', 0]]],
+      [['==', ['+', ['*', 9, 9], 19], 100], {}, true],
+      [['==', ['+', ['*', 9, 9], ['-', ['/', 250, 5], 31]], 100], {}, true],
+      [['AND', ['==', ['+', 1, 1], 2], ['==', ['+', 2, 2], 4]], {}, true],
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        { Ref1: 4 },
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+      ],
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        { Ref1: 1 },
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+      ],
+    ])(
+      '%p with context %p should be simplified to %p',
+      (
+        exp,
+        ctx,
+        expected,
+        strictKeys = undefined,
+        optionalKeys = undefined
+      ) => {
+        const engine = new Engine()
+        expect(engine.simplify(exp, ctx, strictKeys, optionalKeys)).toEqual(
+          expected
+        )
+      }
+    )
+
+    test.each<[ExpressionInput]>([
+      [['+', 5, 5]],
+      [['-', 5, 5]],
+      [['*', 5, 5]],
+      [['/', 5, 5]],
+      [['+', ['AND', ['==', 1, 1]], 1]],
+      [['AND', ['+', 1, -1], ['+', ['-', 1, 1], 1]]],
+      [['NOT', ['+', 1, 1]]],
+    ])('%p should throw', (expression) => {
+      expect(() => engine.simplify(expression, {})).toThrowError(
+        'invalid expression'
+      )
+    })
+  })
+
+  describe('unsafeSimplify', () => {
+    it.each<
+      [
+        Input,
+        ExpressionInput,
+        Context,
+        string[] | undefined,
+        string[] | undefined,
+      ]
+    >([
+      // LOGICAL
+      // OR
+      [
+        true,
+        ['OR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['OR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+        ['OR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['==', '$Ref1', 1],
+        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {
+          Ref1: 1,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {
+          Ref1: 2,
+        },
+        undefined,
+        undefined,
+      ],
+      // AND
+      [
+        false,
+        ['AND', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['AND', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+        ['AND', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['==', '$Ref1', 1],
+        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+        {
+          Ref1: 1,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
+        {
+          Ref1: 2,
+        },
+        undefined,
+        undefined,
+      ],
+      // NOR
+      [
+        ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+        ['NOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['NOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT', ['==', '$Ref1', 1]],
+        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {
+          Ref1: 2,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
+        {
+          Ref1: 1,
+        },
+        undefined,
+        undefined,
+      ],
+      // XOR
+      [
+        true,
+        ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
+        {
+          Ref1: 2,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
+        {
+          Ref1: 3,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT', ['==', '$Ref1', 1]],
+        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 2]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['==', '$Ref1', 1],
+        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 3]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['XOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+        ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
+        ['XOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [false, ['XOR', ['==', 1, 1], ['==', 2, 2]], {}, undefined, undefined],
+      // NOT
+      [true, ['NOT', ['==', 1, 2]], {}, undefined, undefined],
+      [false, ['NOT', ['==', 1, 1]], {}, undefined, undefined],
+      [false, ['NOT', ['==', '$Ref1', 1]], { Ref1: 1 }, undefined, undefined],
+      [
+        ['NOT', ['==', '$Ref1', 1]],
+        ['NOT', ['==', '$Ref1', 1]],
+        {},
+        undefined,
+        undefined,
+      ],
+      // COMPARISON
+      // Eq
+      [true, ['==', 1, 1], {}, undefined, undefined],
+      [false, ['==', 1, 2], {}, undefined, undefined],
+      [true, ['==', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+      [
+        ['==', '$Ref1', '$Ref2'],
+        ['==', '$Ref1', '$Ref2'],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [false, ['==', '$Ref1', [1]], { Ref1: 1 }, undefined, undefined],
+      // NE
+      [false, ['!=', 1, 1], {}, undefined, undefined],
+      [true, ['!=', 1, 2], {}, undefined, undefined],
+      [false, ['!=', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+      [
+        ['!=', '$Ref1', '$Ref2'],
+        ['!=', '$Ref1', '$Ref2'],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['!=', '$Ref1', '$Ref2'],
+        ['!=', '$Ref1', '$Ref2'],
+        { Ref2: 1 },
+        undefined,
+        undefined,
+      ],
+      // GT
+      [true, ['>', 2, 1], {}, undefined, undefined],
+      [false, ['>', 1, 2], {}, undefined, undefined],
+      [['>', '$Ref1', 1], ['>', '$Ref1', 1], {}, undefined, undefined],
+      [['>', 1, '$Ref1'], ['>', 1, '$Ref1'], {}, undefined, undefined],
+      [true, ['>', '$Ref1', 1], { Ref1: 2 }, undefined, undefined],
+      [false, ['>', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
+      [
+        false,
+        ['>', '$Ref1', '2000-01-01'],
+        { Ref1: '1990-01-01' },
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['>', '$Ref1', '$Ref2'],
+        { Ref1: 2, Ref2: 1 },
+        undefined,
+        undefined,
+      ],
+      [false, ['>', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+      // GE
+      [true, ['>=', 2, 1], {}, undefined, undefined],
+      [true, ['>=', 2, 2], {}, undefined, undefined],
+      [false, ['>=', 1, 2], {}, undefined, undefined],
+      [['>=', '$Ref1', 2], ['>=', '$Ref1', 2], {}, undefined, undefined],
+      [['>=', 2, '$Ref1'], ['>=', 2, '$Ref1'], {}, undefined, undefined],
+      [
+        true,
+        ['>=', '$Ref1', '2000-01-01'],
+        { Ref1: '2000-01-01' },
+        undefined,
+        undefined,
+      ],
+      [false, ['>=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+      // LT
+      [true, ['<', 1, 2], {}, undefined, undefined],
+      [false, ['<', 2, 1], {}, undefined, undefined],
+      [true, ['<', 1, '$Ref1'], { Ref1: 2 }, undefined, undefined],
+      [false, ['<', 1, '$Ref1'], { Ref1: 1 }, undefined, undefined],
+      [['<', '$Ref1', 2], ['<', '$Ref1', 2], {}, undefined, undefined],
+      [['<', 2, '$Ref1'], ['<', 2, '$Ref1'], {}, undefined, undefined],
+      [
+        false,
+        ['<', '$Ref1', '1990-01-01'],
+        { Ref1: '2000-01-01' },
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['<', '$Ref1', '$Ref2'],
+        { Ref1: 1, Ref2: 2 },
+        undefined,
+        undefined,
+      ],
+      [false, ['<', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+      // LE
+      [true, ['<=', 1, 2], {}, undefined, undefined],
+      [true, ['<=', 2, 2], {}, undefined, undefined],
+      [false, ['<=', 2, 1], {}, undefined, undefined],
+      [['<=', '$Ref1', 2], ['<=', '$Ref1', 2], {}, undefined, undefined],
+      [['<=', 2, '$Ref1'], ['<=', 2, '$Ref1'], {}, undefined, undefined],
+      [
+        false,
+        ['<=', '$Ref1', '1990-01-01'],
+        { Ref1: '2000-01-01' },
+        undefined,
+        undefined,
+      ],
+      [false, ['<=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
+      // IN
+      [true, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 1 }, undefined, undefined],
+      [false, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
+      [true, ['IN', [1, 2, 3], '$Ref1'], { Ref1: 1 }, undefined, undefined],
+      [
+        ['IN', [1, 2, 3], '$Ref1'],
+        ['IN', [1, 2, 3], '$Ref1'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', '$Ref1', [1, 2, 3]],
+        ['IN', '$Ref1', [1, 2, 3]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+        ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', '$Ref1', [1, 2, 3]],
+        ['OR', ['==', 1, 2], ['IN', '$Ref1', [1, 2, 3]]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', '$Ref1', [1, 2, 3]],
+        ['AND', ['==', 1, 1], ['IN', '$Ref1', [1, 2, 3]]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [false, ['IN', null, [1, 2, 3]], {}, undefined, undefined],
+      [
+        true,
+        ['IN', 1, '$Ref1'],
+        { Ref1: [1, undefined, 3] },
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['IN', '$Ref1', 1],
+        { Ref1: [1, undefined, 3] },
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', '$Ref1', '$Ref2'],
+        ['IN', '$Ref1', '$Ref2'],
+        { Ref1: [1, undefined, 3] },
+        undefined,
+        undefined,
+      ],
+      [
+        ['IN', '$Ref1', '$Ref2'],
+        ['IN', '$Ref1', '$Ref2'],
+        { Ref2: [1, undefined, 3] },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['IN', '$Ref1', '$Ref2'],
+        { Ref1: [1, undefined, 3] },
+        ['Ref1', 'Ref2'],
+        undefined,
+      ],
+      [
+        true,
+        ['IN', '$Ref1', '$Ref2'],
+        { Ref1: [1, undefined, 3], Ref2: 1 },
+        ['Ref1', 'Ref2'],
+        undefined,
+      ],
+      [
+        false,
+        ['IN', '$Ref1', '$Ref2'],
+        { Ref1: 1, Ref2: null },
+        undefined,
+        undefined,
+      ],
+      [false, ['IN', '$Ref1', '$Ref2'], { Ref1: 1 }, ['Ref2'], undefined],
+      // NOT_IN
+      [
+        false,
+        ['NOT IN', '$Ref1', [1, 2, 3]],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [true, ['NOT IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
+      [true, ['NOT IN', [1, 2, 3], '$Ref1'], { Ref1: 4 }, undefined, undefined],
+      [
+        ['NOT IN', '$Ref1', [1, 2, 3]],
+        ['NOT IN', '$Ref1', [1, 2, 3]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+        ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT IN', '$Ref1', [1, 2, 3]],
+        ['OR', ['==', 1, 2], ['NOT IN', '$Ref1', [1, 2, 3]]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['NOT IN', '$Ref1', [1, 2, 3]],
+        ['AND', ['==', 1, 1], ['NOT IN', '$Ref1', [1, 2, 3]]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [true, ['NOT IN', null, [1, 2, 3]], {}, undefined, undefined],
+      [
+        ['NOT IN', [1, 2, 3], '$Ref1'],
+        ['NOT IN', [1, 2, 3], '$Ref1'],
+        {},
+        undefined,
+        undefined,
+      ],
+      // PREFIX
+      [
+        true,
+        ['PREFIX', 'abc', '$Ref1'],
+        { Ref1: 'abcdef' },
+        undefined,
+        undefined,
+      ],
+      [false, ['PREFIX', 'abc', '$Ref1'], { Ref1: 'ab' }, undefined, undefined],
+      [
+        false,
+        ['PREFIX', 'abc', '$Ref1'],
+        { Ref1: 'xyz' },
+        undefined,
+        undefined,
+      ],
+      [
+        ['PREFIX', '$Ref1', 'abc'],
+        ['PREFIX', '$Ref1', 'abc'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['PREFIX', 'abc', '$Ref1'],
+        ['PREFIX', 'abc', '$Ref1'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [false, ['PREFIX', 1, '$Ref1'], { Ref1: 'abcdef' }, undefined, undefined],
+      // SUFFIX
+      [
+        true,
+        ['SUFFIX', '$Ref1', 'xyz'],
+        { Ref1: 'abcdefxyz' },
+        undefined,
+        undefined,
+      ],
+      [false, ['SUFFIX', '$Ref1', 'xyz'], { Ref1: 'yz' }, undefined, undefined],
+      [
+        false,
+        ['SUFFIX', '$Ref1', 'xyz'],
+        { Ref1: 'abc' },
+        undefined,
+        undefined,
+      ],
+      [
+        ['SUFFIX', 'xyz', '$Ref1'],
+        ['SUFFIX', 'xyz', '$Ref1'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['SUFFIX', '$Ref1', 'xyz'],
+        ['SUFFIX', '$Ref1', 'xyz'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [false, ['SUFFIX', 1, '$Ref1'], { Ref1: 'abcdef' }, undefined, undefined],
+      // OVERLAP
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        {},
+        undefined,
+        undefined,
+      ],
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        {
+          Ref1: 4,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        true,
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        {
+          Ref1: 1,
+        },
+        ['Ref1', 'Ref2'],
+        undefined,
+      ],
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        {},
+        undefined,
+        ['Ref1', 'Ref2'],
+      ],
+      [
+        true,
+        ['OVERLAP', '$Ref1', [1, 2, 3]],
+        {
+          Ref1: [1],
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+        {},
+        ['Ref1', 'Ref2'],
+        undefined,
+      ],
+      [false, ['OVERLAP', [1, 2, 3], '$Ref1'], {}, ['Ref1'], undefined],
+      [
+        ['OVERLAP', [1, 2, 3], '$Ref1'],
+        ['OVERLAP', [1, 2, 3], '$Ref1'],
+        {},
+        undefined,
+        ['Ref1'],
+      ],
+      [
+        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+        ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
+        {
+          Ref1: 4,
+        },
+        undefined,
+        undefined,
+      ],
+      [
         [
-          Input,
-          ExpressionInput,
-          Context,
-          string[] | undefined,
-          string[] | undefined,
-        ]
-      >([
-        // LOGICAL
-        // OR
-        [
-          true,
-          ['OR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
+          'OVERLAP',
+          ['$Location1Address.region', '$Location2Address.region'],
+          ['DE', 'PA'],
         ],
         [
-          ['OR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-          ['OR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
+          'OVERLAP',
+          ['$Location1Address.region', '$Location2Address.region'],
+          ['DE', 'PA'],
         ],
-        [
-          ['==', '$Ref1', 1],
-          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {
-            Ref1: 1,
+        {
+          Location1Address: {
+            street: '633 E Lake Ave',
+            city: 'Peoria',
+            region: 'IL',
+            postalCode: '61614',
+            county: '',
+            country: 'US',
+            secondary: '',
           },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['OR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {
-            Ref1: 2,
+          Location1Wc1Code: {
+            code: '9102-2',
+            industry: '',
           },
-          undefined,
-          undefined,
-        ],
-        // AND
-        [
-          false,
-          ['AND', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['AND', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-          ['AND', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['==', '$Ref1', 1],
-          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-          {
-            Ref1: 1,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['AND', ['==', 1, 1], ['==', 2, 2], ['==', '$Ref1', 1]],
-          {
-            Ref1: 2,
-          },
-          undefined,
-          undefined,
-        ],
-        // NOR
-        [
-          ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-          ['NOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['NOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT', ['==', '$Ref1', 1]],
-          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {
-            Ref1: 2,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['NOR', ['==', 1, 2], ['==', 2, 3], ['==', '$Ref1', 1]],
-          {
-            Ref1: 1,
-          },
-          undefined,
-          undefined,
-        ],
-        // XOR
-        [
-          true,
-          ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
-          {
-            Ref1: 2,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['XOR', ['==', '$Ref1', 1], ['==', 2, 3], ['==', '$Ref1', 2]],
-          {
-            Ref1: 3,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT', ['==', '$Ref1', 1]],
-          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 2]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['==', '$Ref1', 1],
-          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', 2, 3]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['XOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-          ['XOR', ['==', '$Ref1', 1], ['==', 1, 2], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOR', ['==', '$Ref1', 1], ['==', '$Ref1', 1]],
-          ['XOR', ['==', '$Ref1', 1], ['==', 1, 1], ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [false, ['XOR', ['==', 1, 1], ['==', 2, 2]], {}, undefined, undefined],
-        // NOT
-        [true, ['NOT', ['==', 1, 2]], {}, undefined, undefined],
-        [false, ['NOT', ['==', 1, 1]], {}, undefined, undefined],
-        [false, ['NOT', ['==', '$Ref1', 1]], { Ref1: 1 }, undefined, undefined],
-        [
-          ['NOT', ['==', '$Ref1', 1]],
-          ['NOT', ['==', '$Ref1', 1]],
-          {},
-          undefined,
-          undefined,
-        ],
-        // COMPARISON
-        // Eq
-        [true, ['==', 1, 1], {}, undefined, undefined],
-        [false, ['==', 1, 2], {}, undefined, undefined],
-        [true, ['==', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-        [
-          ['==', '$Ref1', '$Ref2'],
-          ['==', '$Ref1', '$Ref2'],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [false, ['==', '$Ref1', [1]], { Ref1: 1 }, undefined, undefined],
-        // NE
-        [false, ['!=', 1, 1], {}, undefined, undefined],
-        [true, ['!=', 1, 2], {}, undefined, undefined],
-        [false, ['!=', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-        [
-          ['!=', '$Ref1', '$Ref2'],
-          ['!=', '$Ref1', '$Ref2'],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['!=', '$Ref1', '$Ref2'],
-          ['!=', '$Ref1', '$Ref2'],
-          { Ref2: 1 },
-          undefined,
-          undefined,
-        ],
-        // GT
-        [true, ['>', 2, 1], {}, undefined, undefined],
-        [false, ['>', 1, 2], {}, undefined, undefined],
-        [['>', '$Ref1', 1], ['>', '$Ref1', 1], {}, undefined, undefined],
-        [['>', 1, '$Ref1'], ['>', 1, '$Ref1'], {}, undefined, undefined],
-        [true, ['>', '$Ref1', 1], { Ref1: 2 }, undefined, undefined],
-        [false, ['>', '$Ref1', 1], { Ref1: 1 }, undefined, undefined],
-        [
-          false,
-          ['>', '$Ref1', '2000-01-01'],
-          { Ref1: '1990-01-01' },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['>', '$Ref1', '$Ref2'],
-          { Ref1: 2, Ref2: 1 },
-          undefined,
-          undefined,
-        ],
-        [false, ['>', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-        // GE
-        [true, ['>=', 2, 1], {}, undefined, undefined],
-        [true, ['>=', 2, 2], {}, undefined, undefined],
-        [false, ['>=', 1, 2], {}, undefined, undefined],
-        [['>=', '$Ref1', 2], ['>=', '$Ref1', 2], {}, undefined, undefined],
-        [['>=', 2, '$Ref1'], ['>=', 2, '$Ref1'], {}, undefined, undefined],
-        [
-          true,
-          ['>=', '$Ref1', '2000-01-01'],
-          { Ref1: '2000-01-01' },
-          undefined,
-          undefined,
-        ],
-        [false, ['>=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-        // LT
-        [true, ['<', 1, 2], {}, undefined, undefined],
-        [false, ['<', 2, 1], {}, undefined, undefined],
-        [true, ['<', 1, '$Ref1'], { Ref1: 2 }, undefined, undefined],
-        [false, ['<', 1, '$Ref1'], { Ref1: 1 }, undefined, undefined],
-        [['<', '$Ref1', 2], ['<', '$Ref1', 2], {}, undefined, undefined],
-        [['<', 2, '$Ref1'], ['<', 2, '$Ref1'], {}, undefined, undefined],
-        [
-          false,
-          ['<', '$Ref1', '1990-01-01'],
-          { Ref1: '2000-01-01' },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['<', '$Ref1', '$Ref2'],
-          { Ref1: 1, Ref2: 2 },
-          undefined,
-          undefined,
-        ],
-        [false, ['<', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-        // LE
-        [true, ['<=', 1, 2], {}, undefined, undefined],
-        [true, ['<=', 2, 2], {}, undefined, undefined],
-        [false, ['<=', 2, 1], {}, undefined, undefined],
-        [['<=', '$Ref1', 2], ['<=', '$Ref1', 2], {}, undefined, undefined],
-        [['<=', 2, '$Ref1'], ['<=', 2, '$Ref1'], {}, undefined, undefined],
-        [
-          false,
-          ['<=', '$Ref1', '1990-01-01'],
-          { Ref1: '2000-01-01' },
-          undefined,
-          undefined,
-        ],
-        [false, ['<=', '$Ref1', 2], { Ref1: true }, undefined, undefined],
-        // IN
-        [true, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 1 }, undefined, undefined],
-        [false, ['IN', '$Ref1', [1, 2, 3]], { Ref1: 4 }, undefined, undefined],
-        [true, ['IN', [1, 2, 3], '$Ref1'], { Ref1: 1 }, undefined, undefined],
-        [
-          ['IN', [1, 2, 3], '$Ref1'],
-          ['IN', [1, 2, 3], '$Ref1'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', '$Ref1', [1, 2, 3]],
-          ['IN', '$Ref1', [1, 2, 3]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-          ['IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', '$Ref1', [1, 2, 3]],
-          ['OR', ['==', 1, 2], ['IN', '$Ref1', [1, 2, 3]]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', '$Ref1', [1, 2, 3]],
-          ['AND', ['==', 1, 1], ['IN', '$Ref1', [1, 2, 3]]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [false, ['IN', null, [1, 2, 3]], {}, undefined, undefined],
-        [
-          true,
-          ['IN', 1, '$Ref1'],
-          { Ref1: [1, undefined, 3] },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['IN', '$Ref1', 1],
-          { Ref1: [1, undefined, 3] },
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', '$Ref1', '$Ref2'],
-          ['IN', '$Ref1', '$Ref2'],
-          { Ref1: [1, undefined, 3] },
-          undefined,
-          undefined,
-        ],
-        [
-          ['IN', '$Ref1', '$Ref2'],
-          ['IN', '$Ref1', '$Ref2'],
-          { Ref2: [1, undefined, 3] },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['IN', '$Ref1', '$Ref2'],
-          { Ref1: [1, undefined, 3] },
-          ['Ref1', 'Ref2'],
-          undefined,
-        ],
-        [
-          true,
-          ['IN', '$Ref1', '$Ref2'],
-          { Ref1: [1, undefined, 3], Ref2: 1 },
-          ['Ref1', 'Ref2'],
-          undefined,
-        ],
-        [
-          false,
-          ['IN', '$Ref1', '$Ref2'],
-          { Ref1: 1, Ref2: null },
-          undefined,
-          undefined,
-        ],
-        [false, ['IN', '$Ref1', '$Ref2'], { Ref1: 1 }, ['Ref2'], undefined],
-        // NOT_IN
-        [
-          false,
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          { Ref1: 4 },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['NOT IN', [1, 2, 3], '$Ref1'],
-          { Ref1: 4 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          ['NOT IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-          ['NOT IN', ['$Ref1', '$Ref2', '$Ref3'], 1],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          ['OR', ['==', 1, 2], ['NOT IN', '$Ref1', [1, 2, 3]]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['NOT IN', '$Ref1', [1, 2, 3]],
-          ['AND', ['==', 1, 1], ['NOT IN', '$Ref1', [1, 2, 3]]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [true, ['NOT IN', null, [1, 2, 3]], {}, undefined, undefined],
-        [
-          ['NOT IN', [1, 2, 3], '$Ref1'],
-          ['NOT IN', [1, 2, 3], '$Ref1'],
-          {},
-          undefined,
-          undefined,
-        ],
-        // PREFIX
-        [
-          true,
-          ['PREFIX', 'abc', '$Ref1'],
-          { Ref1: 'abcdef' },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['PREFIX', 'abc', '$Ref1'],
-          { Ref1: 'ab' },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['PREFIX', 'abc', '$Ref1'],
-          { Ref1: 'xyz' },
-          undefined,
-          undefined,
-        ],
-        [
-          ['PREFIX', '$Ref1', 'abc'],
-          ['PREFIX', '$Ref1', 'abc'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['PREFIX', 'abc', '$Ref1'],
-          ['PREFIX', 'abc', '$Ref1'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['PREFIX', 1, '$Ref1'],
-          { Ref1: 'abcdef' },
-          undefined,
-          undefined,
-        ],
-        // SUFFIX
-        [
-          true,
-          ['SUFFIX', '$Ref1', 'xyz'],
-          { Ref1: 'abcdefxyz' },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['SUFFIX', '$Ref1', 'xyz'],
-          { Ref1: 'yz' },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['SUFFIX', '$Ref1', 'xyz'],
-          { Ref1: 'abc' },
-          undefined,
-          undefined,
-        ],
-        [
-          ['SUFFIX', 'xyz', '$Ref1'],
-          ['SUFFIX', 'xyz', '$Ref1'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['SUFFIX', '$Ref1', 'xyz'],
-          ['SUFFIX', '$Ref1', 'xyz'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['SUFFIX', 1, '$Ref1'],
-          { Ref1: 'abcdef' },
-          undefined,
-          undefined,
-        ],
-        // OVERLAP
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          {},
-          undefined,
-          undefined,
-        ],
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          {
-            Ref1: 4,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          {
-            Ref1: 1,
-          },
-          ['Ref1', 'Ref2'],
-          undefined,
-        ],
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          {},
-          undefined,
-          ['Ref1', 'Ref2'],
-        ],
-        [
-          true,
-          ['OVERLAP', '$Ref1', [1, 2, 3]],
-          {
-            Ref1: [1],
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-          {},
-          ['Ref1', 'Ref2'],
-          undefined,
-        ],
-        [false, ['OVERLAP', [1, 2, 3], '$Ref1'], {}, ['Ref1'], undefined],
-        [
-          ['OVERLAP', [1, 2, 3], '$Ref1'],
-          ['OVERLAP', [1, 2, 3], '$Ref1'],
-          {},
-          undefined,
-          ['Ref1'],
-        ],
-        [
-          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-          ['OVERLAP', [1, 2, 3], ['$Ref1', '$Ref2']],
-          {
-            Ref1: 4,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          [
-            'OVERLAP',
-            ['$Location1Address.region', '$Location2Address.region'],
-            ['DE', 'PA'],
-          ],
-          [
-            'OVERLAP',
-            ['$Location1Address.region', '$Location2Address.region'],
-            ['DE', 'PA'],
-          ],
-          {
-            Location1Address: {
-              street: '633 E Lake Ave',
-              city: 'Peoria',
-              region: 'IL',
-              postalCode: '61614',
-              county: '',
-              country: 'US',
-              secondary: '',
-            },
-            Location1Wc1Code: {
-              code: '9102-2',
-              industry: '',
-            },
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          [
-            'OR',
-            [
-              'AND',
-              [
-                'OVERLAP',
-                ['$Location1Address.region', '$Location2Address.region'],
-                ['DE', 'PA'],
-              ],
-              [
-                'OVERLAP',
-                ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
-                ['0936-2'],
-              ],
-            ],
-            [
-              'AND',
-              [
-                'OVERLAP',
-                ['$Location1Address.region', '$Location2Address.region'],
-                ['AK', 'IL'],
-              ],
-              [
-                'OVERLAP',
-                ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
-                ['7610-3'],
-              ],
-            ],
-          ],
-          {
-            Location1Address: {
-              street: '633 E Lake Ave',
-              city: 'Peoria',
-              region: 'IL',
-              postalCode: '61614',
-              county: '',
-              country: 'US',
-              secondary: '',
-            },
-            Location1Wc1Code: {
-              code: '9102-2',
-              industry: '',
-            },
-          },
-          [],
-          [],
-        ],
-        // UNDEFINED
-        [
-          ['UNDEFINED', '$Ref1'],
-          ['UNDEFINED', '$Ref1'],
-          {},
-          undefined,
-          undefined,
-        ],
-        [true, ['UNDEFINED', '$Ref1'], {}, ['Ref1'], undefined],
-        [
-          ['UNDEFINED', '$Ref1'],
-          ['UNDEFINED', '$Ref1'],
-          {},
-          undefined,
-          ['Ref1'],
-        ],
-        [false, ['UNDEFINED', '$Ref1'], { Ref1: false }, ['Ref1'], undefined],
-        [
-          ['UNDEFINED', '$Ref1'],
-          ['UNDEFINED', '$Ref1'],
-          { Ref1: undefined },
-          undefined,
-          undefined,
-        ],
-        [
-          false,
-          ['UNDEFINED', '$Ref1'],
-          { Ref1: 'value' },
-          undefined,
-          undefined,
-        ],
-        [false, ['UNDEFINED', '$Ref1'], { Ref1: null }, undefined, undefined],
-        // PRESENT
-        [
-          ['PRESENT', '$Ref1'],
-          ['PRESENT', '$Ref1'],
-          { Ref1: undefined },
-          undefined,
-          undefined,
-        ],
-        [true, ['PRESENT', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
-        [false, ['PRESENT', '$Ref1'], { Ref1: null }, undefined, undefined],
-        [true, ['PRESENT', '$Ref1'], { Ref1: false }, undefined, undefined],
-        [false, ['PRESENT', '$Ref1'], {}, ['Ref1'], undefined],
-        [
-          true,
-          ['PRESENT', '$Ref1'],
-          { Ref1: { obj: 'obj' } },
-          undefined,
-          undefined,
-        ],
-        // ARITHMETIC
-        // SUM
-        [true, ['>', ['+', 1, 2, 3], 5], {}, undefined, undefined],
-        [
-          true,
-          ['>', ['+', '$Ref1', '$Ref2'], 2],
-          { Ref1: 1, Ref2: 2 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['>', ['+', '$Ref1', '$Ref2'], 0],
-          ['>', ['+', '$Ref1', '$Ref2'], 0],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['>', ['+', '$Ref1', '$Ref2'], 3],
-          ['>', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['>=', ['+', '$Ref1', '$Ref2'], 3],
-          ['>=', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['<', ['+', '$Ref1', '$Ref2'], 0],
-          ['<', ['+', '$Ref1', '$Ref2'], 0],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['<=', ['+', '$Ref1', '$Ref2'], 0],
-          ['<=', ['+', '$Ref1', '$Ref2'], 0],
-          { Ref1: 1 },
-          undefined,
-          undefined,
-        ],
-        [
-          true,
-          ['>', ['+', '$Ref1', 5], 10],
-          { Ref1: 10 },
-          undefined,
-          undefined,
-        ],
-        [true, ['<', ['+', '$Ref1', 5], 10], { Ref1: 0 }, undefined, undefined],
-        [
-          true,
-          ['<', ['+', '$Ref1', 5], 0],
-          { Ref1: -10 },
-          undefined,
-          undefined,
-        ],
-        [false, ['>', ['+', null, null], 5], {}, undefined, undefined],
-        [
-          false,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        false,
+        [
+          'OR',
           [
             'AND',
             [
-              '>',
-              [
-                '+',
-                '$Location2Wc1NumberOfFullTimeEmployees',
-                '$Location2Wc1NumberOfPartTimeEmployees',
-              ],
-              99,
+              'OVERLAP',
+              ['$Location1Address.region', '$Location2Address.region'],
+              ['DE', 'PA'],
             ],
-            ['>=', '$NumberOfLocations', 2],
+            [
+              'OVERLAP',
+              ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
+              ['0936-2'],
+            ],
           ],
-          { NumberOfLocations: 1 },
           [
-            'Location2Wc1NumberOfFullTimeEmployees',
-            'Location2Wc1NumberOfPartTimeEmployees',
+            'AND',
+            [
+              'OVERLAP',
+              ['$Location1Address.region', '$Location2Address.region'],
+              ['AK', 'IL'],
+            ],
+            [
+              'OVERLAP',
+              ['$Location1Wc1Code.code', '$Location2Wc1Code.code'],
+              ['7610-3'],
+            ],
           ],
+        ],
+        {
+          Location1Address: {
+            street: '633 E Lake Ave',
+            city: 'Peoria',
+            region: 'IL',
+            postalCode: '61614',
+            county: '',
+            country: 'US',
+            secondary: '',
+          },
+          Location1Wc1Code: {
+            code: '9102-2',
+            industry: '',
+          },
+        },
+        [],
+        [],
+      ],
+      // UNDEFINED
+      [
+        ['UNDEFINED', '$Ref1'],
+        ['UNDEFINED', '$Ref1'],
+        {},
+        undefined,
+        undefined,
+      ],
+      [true, ['UNDEFINED', '$Ref1'], {}, ['Ref1'], undefined],
+      [['UNDEFINED', '$Ref1'], ['UNDEFINED', '$Ref1'], {}, undefined, ['Ref1']],
+      [false, ['UNDEFINED', '$Ref1'], { Ref1: false }, ['Ref1'], undefined],
+      [
+        ['UNDEFINED', '$Ref1'],
+        ['UNDEFINED', '$Ref1'],
+        { Ref1: undefined },
+        undefined,
+        undefined,
+      ],
+      [false, ['UNDEFINED', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
+      [false, ['UNDEFINED', '$Ref1'], { Ref1: null }, undefined, undefined],
+      // PRESENT
+      [
+        ['PRESENT', '$Ref1'],
+        ['PRESENT', '$Ref1'],
+        { Ref1: undefined },
+        undefined,
+        undefined,
+      ],
+      [true, ['PRESENT', '$Ref1'], { Ref1: 'value' }, undefined, undefined],
+      [false, ['PRESENT', '$Ref1'], { Ref1: null }, undefined, undefined],
+      [true, ['PRESENT', '$Ref1'], { Ref1: false }, undefined, undefined],
+      [false, ['PRESENT', '$Ref1'], {}, ['Ref1'], undefined],
+      [
+        true,
+        ['PRESENT', '$Ref1'],
+        { Ref1: { obj: 'obj' } },
+        undefined,
+        undefined,
+      ],
+      // ARITHMETIC
+      // SUM
+      [true, ['>', ['+', 1, 2, 3], 5], {}, undefined, undefined],
+      [
+        true,
+        ['>', ['+', '$Ref1', '$Ref2'], 2],
+        { Ref1: 1, Ref2: 2 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>', ['+', '$Ref1', '$Ref2'], 0],
+        ['>', ['+', '$Ref1', '$Ref2'], 0],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>', ['+', '$Ref1', '$Ref2'], 3],
+        ['>', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>=', ['+', '$Ref1', '$Ref2'], 3],
+        ['>=', ['+', '$Ref1', '$Ref2'], ['+', 1, 2]],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['<', ['+', '$Ref1', '$Ref2'], 0],
+        ['<', ['+', '$Ref1', '$Ref2'], 0],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['<=', ['+', '$Ref1', '$Ref2'], 0],
+        ['<=', ['+', '$Ref1', '$Ref2'], 0],
+        { Ref1: 1 },
+        undefined,
+        undefined,
+      ],
+      [true, ['>', ['+', '$Ref1', 5], 10], { Ref1: 10 }, undefined, undefined],
+      [true, ['<', ['+', '$Ref1', 5], 10], { Ref1: 0 }, undefined, undefined],
+      [true, ['<', ['+', '$Ref1', 5], 0], { Ref1: -10 }, undefined, undefined],
+      [false, ['>', ['+', null, null], 5], {}, undefined, undefined],
+      [
+        false,
+        [
+          'AND',
           [
-            'Location2Wc1NumberOfFullTimeEmployees',
-            'Location2Wc1NumberOfPartTimeEmployees',
+            '>',
+            [
+              '+',
+              '$Location2Wc1NumberOfFullTimeEmployees',
+              '$Location2Wc1NumberOfPartTimeEmployees',
+            ],
+            99,
           ],
+          ['>=', '$NumberOfLocations', 2],
         ],
-        // SUBTRACT
-        [true, ['>', ['-', 5, 2], 2], {}, undefined, undefined],
+        { NumberOfLocations: 1 },
         [
-          true,
-          ['>', ['-', '$Ref1', '$Ref2'], 2],
-          { Ref1: 5, Ref2: 2 },
-          undefined,
-          undefined,
+          'Location2Wc1NumberOfFullTimeEmployees',
+          'Location2Wc1NumberOfPartTimeEmployees',
         ],
         [
-          ['>', ['-', '$Ref1', '$Ref2'], 0],
-          ['>', ['-', '$Ref1', '$Ref2'], 0],
-          { Ref1: 5 },
-          undefined,
-          undefined,
+          'Location2Wc1NumberOfFullTimeEmployees',
+          'Location2Wc1NumberOfPartTimeEmployees',
         ],
-        [
-          ['>', ['-', '$Ref1', '$Ref2'], 3],
-          ['>', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
-          { Ref1: 5 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['>=', ['-', '$Ref1', '$Ref2'], 3],
-          ['>=', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
-          { Ref1: 5 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['<', ['-', '$Ref1', '$Ref2'], 0],
-          ['<', ['-', '$Ref1', '$Ref2'], 0],
-          { Ref1: 5 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['<=', ['-', '$Ref1', '$Ref2'], 0],
-          ['<=', ['-', '$Ref1', '$Ref2'], 0],
-          { Ref1: 5 },
-          undefined,
-          undefined,
-        ],
-        [false, ['>', ['-', null, null], 5], {}, undefined, undefined],
-        // MULTIPLY
-        [true, ['>', ['*', 2, 3], 5], {}, undefined, undefined],
-        [
-          true,
-          ['>', ['*', '$Ref1', '$Ref2'], 2],
-          { Ref1: 2, Ref2: 3 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['<', ['*', '$Ref1', '$Ref2'], 0],
-          ['<', ['*', '$Ref1', '$Ref2'], 0],
-          { Ref1: 5 },
-          undefined,
-          undefined,
-        ],
-        [false, ['>', ['*', null, null], 5], {}, undefined, undefined],
-        // DIVIDE
-        [true, ['>=', ['/', 10, 2], 5], {}, undefined, undefined],
-        [
-          true,
-          ['>=', ['/', '$Ref1', '$Ref2'], 2],
-          { Ref1: 10, Ref2: 5 },
-          undefined,
-          undefined,
-        ],
-        [
-          ['>', ['/', '$Ref1', '$Ref2'], 0],
-          ['>', ['/', '$Ref1', '$Ref2'], 0],
-          { Ref1: 10 },
-          undefined,
-          undefined,
-        ],
-        [false, ['>', ['/', null, null], 5], {}, undefined, undefined],
-      ])(
-        'should result in %j',
-        (expectedResult, condition, context, strictKeys, optionalKeys) => {
-          const safeResult = engine.simplify(
-            condition,
-            context,
-            strictKeys,
-            optionalKeys
-          )
-          const unsafeResult = engine.unsafeSimplify(
-            condition,
-            context,
-            strictKeys,
-            optionalKeys
-          )
-          expect(safeResult).toEqual(expectedResult)
-          expect(unsafeResult).toEqual(expectedResult)
-          expect(safeResult).toEqual(unsafeResult)
-        }
-      )
-
-      it.each<
-        [
-          Input,
-          Input,
-          ExpressionInput,
-          Context,
-          string[] | undefined,
-          string[] | undefined,
-        ]
-      >([
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
-          true,
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
-          {
-            Ref1: 1,
-          },
-          undefined,
-          undefined,
-        ],
-        [
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          true,
-          ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
-          {
-            Ref1: 1,
-          },
-          [],
-          ['Ref1', 'Ref2'],
-        ],
-        [
-          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          true,
-          ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
-          {
-            Ref1: 1,
-          },
-          undefined,
-          undefined,
-        ],
-      ])(
-        'should have different results as %j and %j',
-        (
-          expectedSafeResult,
-          expectedUnsafeResult,
+      ],
+      // SUBTRACT
+      [true, ['>', ['-', 5, 2], 2], {}, undefined, undefined],
+      [
+        true,
+        ['>', ['-', '$Ref1', '$Ref2'], 2],
+        { Ref1: 5, Ref2: 2 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>', ['-', '$Ref1', '$Ref2'], 0],
+        ['>', ['-', '$Ref1', '$Ref2'], 0],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>', ['-', '$Ref1', '$Ref2'], 3],
+        ['>', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>=', ['-', '$Ref1', '$Ref2'], 3],
+        ['>=', ['-', '$Ref1', '$Ref2'], ['+', 1, 2]],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['<', ['-', '$Ref1', '$Ref2'], 0],
+        ['<', ['-', '$Ref1', '$Ref2'], 0],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['<=', ['-', '$Ref1', '$Ref2'], 0],
+        ['<=', ['-', '$Ref1', '$Ref2'], 0],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [false, ['>', ['-', null, null], 5], {}, undefined, undefined],
+      // MULTIPLY
+      [true, ['>', ['*', 2, 3], 5], {}, undefined, undefined],
+      [
+        true,
+        ['>', ['*', '$Ref1', '$Ref2'], 2],
+        { Ref1: 2, Ref2: 3 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['<', ['*', '$Ref1', '$Ref2'], 0],
+        ['<', ['*', '$Ref1', '$Ref2'], 0],
+        { Ref1: 5 },
+        undefined,
+        undefined,
+      ],
+      [false, ['>', ['*', null, null], 5], {}, undefined, undefined],
+      // DIVIDE
+      [true, ['>=', ['/', 10, 2], 5], {}, undefined, undefined],
+      [
+        true,
+        ['>=', ['/', '$Ref1', '$Ref2'], 2],
+        { Ref1: 10, Ref2: 5 },
+        undefined,
+        undefined,
+      ],
+      [
+        ['>', ['/', '$Ref1', '$Ref2'], 0],
+        ['>', ['/', '$Ref1', '$Ref2'], 0],
+        { Ref1: 10 },
+        undefined,
+        undefined,
+      ],
+      [false, ['>', ['/', null, null], 5], {}, undefined, undefined],
+    ])(
+      'should result in %j',
+      (expectedResult, condition, context, strictKeys, optionalKeys) => {
+        const safeResult = engine.simplify(
           condition,
           context,
           strictKeys,
           optionalKeys
-        ) => {
-          const safeResult = engine.simplify(
-            condition,
-            context,
-            strictKeys,
-            optionalKeys
-          )
-          const unsafeResult = engine.unsafeSimplify(
-            condition,
-            context,
-            strictKeys,
-            optionalKeys
-          )
-          expect(safeResult).toEqual(expectedSafeResult)
-          expect(unsafeResult).toEqual(expectedUnsafeResult)
-        }
-      )
-
-      it('should be closer to 100% code coverage', () => {
-        expect(() =>
-          engine.unsafeSimplify(
-            ['OR', [1, [1, '$Ref1', 1], 3], ['==', 1, 1]],
-            {}
-          )
-        ).toThrow(
-          'Unexpected expression found within a collection of values/references'
         )
-      })
+        const unsafeResult = engine.unsafeSimplify(
+          condition,
+          context,
+          strictKeys,
+          optionalKeys
+        )
+        expect(safeResult).toEqual(expectedResult)
+        expect(unsafeResult).toEqual(expectedResult)
+        expect(safeResult).toEqual(unsafeResult)
+      }
+    )
+
+    it.each<
+      [
+        Input,
+        Input,
+        ExpressionInput,
+        Context,
+        string[] | undefined,
+        string[] | undefined,
+      ]
+    >([
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
+        true,
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3, '$Ref3']],
+        {
+          Ref1: 1,
+        },
+        undefined,
+        undefined,
+      ],
+      [
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        true,
+        ['OVERLAP', ['$Ref1', '$Ref2'], [1, 2, 3]],
+        {
+          Ref1: 1,
+        },
+        [],
+        ['Ref1', 'Ref2'],
+      ],
+      [
+        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        true,
+        ['IN', 1, ['$Ref1', '$Ref2', '$Ref3']],
+        {
+          Ref1: 1,
+        },
+        undefined,
+        undefined,
+      ],
+    ])(
+      'should have different results as %j and %j',
+      (
+        expectedSafeResult,
+        expectedUnsafeResult,
+        condition,
+        context,
+        strictKeys,
+        optionalKeys
+      ) => {
+        const safeResult = engine.simplify(
+          condition,
+          context,
+          strictKeys,
+          optionalKeys
+        )
+        const unsafeResult = engine.unsafeSimplify(
+          condition,
+          context,
+          strictKeys,
+          optionalKeys
+        )
+        expect(safeResult).toEqual(expectedSafeResult)
+        expect(unsafeResult).toEqual(expectedUnsafeResult)
+      }
+    )
+
+    it('should be closer to 100% code coverage', () => {
+      expect(() =>
+        engine.unsafeSimplify(['OR', [1, [1, '$Ref1', 1], 3], ['==', 1, 1]], {})
+      ).toThrow(
+        'Unexpected expression found within a collection of values/references'
+      )
     })
-  }
-)
+  })
+})

--- a/src/operand/__test__/unit/reference.test.ts
+++ b/src/operand/__test__/unit/reference.test.ts
@@ -148,6 +148,7 @@ describe('Operand - Value', () => {
       ['RefB', new Reference('RefB'), undefined, ['RefB']],
       ['RefB', new Reference('RefB'), [], ['RefB']],
       ['RefB', new Reference('RefB'), undefined, undefined],
+      ['RefB.code', new Reference('RefB.code'), undefined, undefined],
     ])(
       '%p should simplify to %p',
       (value, expected, strictKeys = undefined, optionalKeys = undefined) => {

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -12,7 +12,7 @@ const arrayIndexRegex = /\[(\d+)]/g
 
 const backTick = '`'
 function parseBacktickWrappedKey(key: string) {
-  return key.startsWith(backTick) && key.endsWith(backTick)
+  return key[0] === backTick && key[key.length - 1] === backTick
     ? key.slice(1, -1)
     : key
 }
@@ -115,7 +115,7 @@ const dataTypeRegex = new RegExp(
 
 const isComplexKey = (key: string) => key.indexOf('{') > -1
 
-const castingRegex = /.\(.+\)$/
+const castingRegex = /\.\(.+\)$/
 
 /**
  * Reference operand resolved within the context

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -10,8 +10,11 @@ const keyWithArrayIndexRegex =
   /^(?<currentKey>[^[\]]+?)(?<indexes>(?:\[\d+])+)?$/
 const arrayIndexRegex = /\[(\d+)]/g
 
+const backTick = '`'
 function parseBacktickWrappedKey(key: string) {
-  return key.startsWith('`') && key.endsWith('`') ? key.slice(1, -1) : key
+  return key.startsWith(backTick) && key.endsWith(backTick)
+    ? key.slice(1, -1)
+    : key
 }
 
 function parseKeyComponents(key: string) {
@@ -35,8 +38,10 @@ function parseKeyComponents(key: string) {
   return keys
 }
 
+const parseKeyRegex = /(`[^[\]]+`(\[\d+\])*|[^`.]+)/g
+
 function parseKey(key: string): Keys {
-  const keys = key.match(/(`[^[\]]+`(\[\d+\])*|[^`.]+)/g)
+  const keys = key.match(parseKeyRegex)
   return !keys ? [] : keys.flatMap(parseKeyComponents)
 }
 
@@ -110,6 +115,8 @@ const dataTypeRegex = new RegExp(
 
 const isComplexKey = (key: string) => key.indexOf('{') > -1
 
+const castingRegex = /.\(.+\)$/
+
 /**
  * Reference operand resolved within the context
  */
@@ -135,8 +142,8 @@ export class Reference extends Operand {
       this.dataType = DataType[dataTypeMatch[1] as keyof typeof DataType]
     }
 
-    if (this.key.match(/.\(.+\)$/)) {
-      this.key = this.key.replace(/.\(.+\)$/, '')
+    if (this.key.match(castingRegex)) {
+      this.key = this.key.replace(castingRegex, '')
     }
     if (isComplexKey(this.key)) {
       this.valueLookup = (context) => complexValueLookup(context, this.key)

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -10,11 +10,8 @@ const keyWithArrayIndexRegex =
   /^(?<currentKey>[^[\]]+?)(?<indexes>(?:\[\d+])+)?$/
 const arrayIndexRegex = /\[(\d+)]/g
 
-const backTick = '`'
 function parseBacktickWrappedKey(key: string) {
-  return key[0] === backTick && key[key.length - 1] === backTick
-    ? key.slice(1, -1)
-    : key
+  return key[0] === '`' && key[key.length - 1] === '`' ? key.slice(1, -1) : key
 }
 
 function parseKeyComponents(key: string) {

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -14,7 +14,7 @@ function parseBacktickWrappedKey(key: string) {
   return key.startsWith('`') && key.endsWith('`') ? key.slice(1, -1) : key
 }
 
-function mapKeys(key: string) {
+function parseKeyComponents(key: string) {
   const unwrappedKey = parseBacktickWrappedKey(key)
   const keys: Keys = []
   const parseResult = keyWithArrayIndexRegex.exec(unwrappedKey)
@@ -37,7 +37,7 @@ function mapKeys(key: string) {
 
 function parseKey(key: string): Keys {
   const keys = key.match(/(`[^[\]]+`(\[\d+\])*|[^`.]+)/g)
-  return !keys ? [] : keys.flatMap(mapKeys)
+  return !keys ? [] : keys.flatMap(parseKeyComponents)
 }
 
 const complexKeyExpression = /{([^{}]+)}/

--- a/src/operand/reference.ts
+++ b/src/operand/reference.ts
@@ -137,11 +137,9 @@ export class Reference extends Operand {
     const dataTypeMatch = dataTypeRegex.exec(this.key)
     if (dataTypeMatch) {
       this.dataType = DataType[dataTypeMatch[1] as keyof typeof DataType]
-    }
-
-    if (this.key.match(castingRegex)) {
       this.key = this.key.replace(castingRegex, '')
     }
+
     if (isComplexKey(this.key)) {
       this.valueLookup = (context) => complexValueLookup(context, this.key)
       this.getKeys = (context) => extractComplexKeys(context, this.key)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,4 +1,5 @@
 import { Evaluable, EvaluableType } from '../common/evaluable'
+import { isString } from '../common/type-check'
 import {
   Divide,
   OPERATOR as OPERATOR_DIVIDE,
@@ -155,8 +156,8 @@ export class Parser {
   }
 
   private resolve(raw: Input): Value | Reference {
-    return this.opts.referencePredicate(raw as string)
-      ? this.getReference(raw as string)
+    return isString(raw) && this.opts.referencePredicate(raw)
+      ? this.getReference(raw)
       : new Value(raw)
   }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -138,8 +138,11 @@ export class Parser {
   }
 
   private getReference(key: string): Reference {
-    if (this.options.cacheReferences && this.referenceCache.has(key)) {
-      return this.referenceCache.get(key)!
+    if (this.options.cacheReferences) {
+      const cached = this.referenceCache.get(key)
+      if (cached) {
+        return cached
+      }
     }
 
     const reference = new Reference(this.opts.referenceTransform(key))

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -141,8 +141,13 @@ export class Parser {
     if (this.options.cacheReferences && this.referenceCache.has(key)) {
       return this.referenceCache.get(key)!
     }
+
     const reference = new Reference(this.opts.referenceTransform(key))
-    this.referenceCache.set(key, reference)
+
+    if (this.options.cacheReferences) {
+      this.referenceCache.set(key, reference)
+    }
+
     return reference
   }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -357,7 +357,11 @@ export class Parser {
    */
   private getOperand(raw: Input): Operand {
     if (Array.isArray(raw)) {
-      return new Collection(raw.map((item) => this.resolve(item)))
+      const collectionItems: (Value | Reference)[] = []
+      for (const item of raw) {
+        collectionItems.push(this.resolve(item))
+      }
+      return new Collection(collectionItems)
     }
     return this.resolve(raw)
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -140,7 +140,7 @@ export class Parser {
   private getReference(key: string): Reference {
     if (this.options.cacheReferences) {
       const cached = this.referenceCache.get(key)
-      if (cached) {
+      if (cached !== undefined) {
         return cached
       }
     }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -139,18 +139,14 @@ export class Parser {
   }
 
   private getReference(key: string): Reference {
-    if (this.options.cacheReferences) {
-      const cached = this.referenceCache.get(key)
-      if (cached !== undefined) {
-        return cached
-      }
+    const cached = this.referenceCache.get(key)
+    if (cached !== undefined) {
+      return cached
     }
 
     const reference = new Reference(this.opts.referenceTransform(key))
 
-    if (this.options.cacheReferences) {
-      this.referenceCache.set(key, reference)
-    }
+    this.referenceCache.set(key, reference)
 
     return reference
   }

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -84,7 +84,7 @@ export interface Options {
  * @return {boolean}
  */
 export function defaultReferencePredicate(key: string): boolean {
-  return isString(key) && (key as string).startsWith('$')
+  return isString(key) && key[0] === '$'
 }
 
 /**

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -25,7 +25,6 @@ import { OPERATOR as OPERATOR_XOR } from '../expression/logical/xor'
 export type optionValue =
   | ((operand: string) => string | boolean)
   | Map<symbol, string>
-  | boolean
 
 // Parser options
 export interface Options {

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -1,4 +1,3 @@
-import { isString } from '../common/type-check'
 import { OPERATOR as OPERATOR_DIVIDE } from '../expression/arithmetic/divide'
 import { OPERATOR as OPERATOR_MULTIPLY } from '../expression/arithmetic/multiply'
 import { OPERATOR as OPERATOR_SUBTRACT } from '../expression/arithmetic/subtract'
@@ -84,7 +83,7 @@ export interface Options {
  * @return {boolean}
  */
 export function defaultReferencePredicate(key: string): boolean {
-  return isString(key) && key[0] === '$'
+  return key[0] === '$'
 }
 
 /**

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -68,8 +68,6 @@ export interface Options {
    */
   operatorMapping: Map<symbol, string>
 
-  cacheReferences: boolean
-
   // Object key accessor whitelisting
   [k: string]: optionValue
 }
@@ -138,5 +136,4 @@ export const defaultOptions: Options = {
   referenceTransform: defaultReferenceTransform,
   referenceSerialization: defaultReferenceSerialization,
   operatorMapping: defaultOperatorMapping,
-  cacheReferences: false,
 }

--- a/src/parser/options.ts
+++ b/src/parser/options.ts
@@ -26,6 +26,7 @@ import { OPERATOR as OPERATOR_XOR } from '../expression/logical/xor'
 export type optionValue =
   | ((operand: string) => string | boolean)
   | Map<symbol, string>
+  | boolean
 
 // Parser options
 export interface Options {
@@ -67,6 +68,8 @@ export interface Options {
    * is the key used to represent the  given operator in the raw expression.
    */
   operatorMapping: Map<symbol, string>
+
+  cacheReferences: boolean
 
   // Object key accessor whitelisting
   [k: string]: optionValue
@@ -136,4 +139,5 @@ export const defaultOptions: Options = {
   referenceTransform: defaultReferenceTransform,
   referenceSerialization: defaultReferenceSerialization,
   operatorMapping: defaultOperatorMapping,
+  cacheReferences: false,
 }


### PR DESCRIPTION
# Description
- Add an option to cache References (not on by default just so it's not a breaking change)
- Is there any scenario where this would cause issues?
- [x] Compare memory footprint between both

## QA with a very large condition
### Cache FALSE - with strictKeys and optionalKeys
```
illogical.parse in 31 ms
Evaluable.simplify in 5 ms
Evaluable.simplify result false
```
### Cache TRUE - with strictKeys and optionalKeys
```
illogical.parse in 5 ms
Evaluable.simplify in 4 ms
Evaluable.simplify result false
```
### Cache FALSE - without strictKeys and optionalKeys
```
illogical.parse in 38 ms
Evaluable.simplify in 2 ms
Evaluable.simplify result Or {
  type: 'Expression',
  operator: 'OR',
  operatorSymbol: Symbol(OR),
  operands: [
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    }
  ]
}

```
### Cache TRUE - without strictKeys and optionalKeys
```
illogical.parse in 6 ms
Evaluable.simplify in 2 ms
Evaluable.simplify result Or {
  type: 'Expression',
  operator: 'OR',
  operatorSymbol: Symbol(OR),
  operands: [
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    },
    Or {
      type: 'Expression',
      operator: 'OR',
      operatorSymbol: Symbol(OR),
      operands: [Array]
    }
  ]
}
```

Actual Diff between simplifications match :heavy_check_mark: 
<img width="1173" height="536" alt="image" src="https://github.com/user-attachments/assets/25ccb305-b4cf-4835-97a3-03073ff38755" />

### Supplying an answer that will simplify to true
### Cache FALSE - with strictKeys and optionalKeys
```
illogical.parse in 34 ms
Evaluable.simplify in 4 ms
Evaluable.simplify result true
```
### Cache TRUE - with strictKeys and optionalKeys
```
illogical.parse in 5 ms
Evaluable.simplify in 4 ms
Evaluable.simplify result true
```

## Memory analysis
Caching and reusing each Reference for the same string reduces a lot of memory consumption
<img width="506" height="301" alt="image" src="https://github.com/user-attachments/assets/c8dff259-b998-4cf5-98ef-b8263d8d5971" />

### Using the heap snapshot from Chome Dev Tools
Snapshots were taken before evaluations, then with a loop that kept simplifying it
Without cache
<img width="205" height="156" alt="image" src="https://github.com/user-attachments/assets/39415311-bcd1-433f-8e8c-75f3d9f872db" />
With cache
<img width="204" height="181" alt="image" src="https://github.com/user-attachments/assets/024b3654-7ce9-4ae8-9464-dc969ea5539c" />


### Test Coverage
- [x] unit

#### References
- Closes GUS-5917