### PR TITLE
Clean up the first docs pages users are likely to read

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,76 +1,74 @@
-# Contributor Covenant Code of Conduct
+
+# Contributor Covenant 3.0 Code of Conduct
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-## Our Standards
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 
-Examples of behavior that contributes to creating a positive environment
-include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+## Encouraged Behaviors
 
-Examples of unacceptable behavior by participants include:
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
-## Our Responsibilities
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the Briza project team at [info@briza.io].
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at info@briza.io. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
 
-[homepage]: https://www.contributor-covenant.org
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).
+

--- a/contributing.md
+++ b/contributing.md
@@ -1,13 +1,14 @@
-## Contributing
-When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
+# Contributing
 
-### Pull Request Process
-1. Fork it
-2. Create new branch
-   - **Feature** branch: ```git checkout -b feature/new-feature-name``` or ```git checkout -b feature/issue-number```
-   - **Bug** brach: ```git checkout -b bug/issue-number```
-   - **Hotfix** branch: ```git checkout -b hotfix/issue-number```
-1. Commit your changes (git commit -am 'Add some feature')
-2. Push to the branch (git push origin ft/new-feature-name)
-3. Create new Pull Request
-> Please make an issue first if the change is likely to increase.
+To contribute to this repository, please first discuss the change you wish to make by creating an issue or sending an email. Please do not begin with a pull request, but rather with a conversation, especially for non-trivial changes. Thank you!
+
+## Pull Request Process
+
+1. Fork the repo to your GitHub account and create a local clone
+2. Create a new branch, named according to the type of change you are submitting:
+   - **Feature** branch: `git checkout -b feature/new-feature-name` or `git checkout -b feature/issue-number`
+   - **Bug** brach: `git checkout -b bug/issue-number`
+   - **Hotfix** branch: `git checkout -b hotfix/issue-number`
+1. Commit your changes `git commit -am 'Add useful new feature`
+2. Push to the branch `git push origin feature/new-feature-name`
+3. Create the Pull Request in the GitHub UI

--- a/readme.md
+++ b/readme.md
@@ -8,32 +8,36 @@
   <div align="center">
     <h3 align="center">illogical</h3>
   </div>
-
-[![build status](https://github.com/briza-insurance/illogical/actions/workflows/test.yml/badge.svg)](https://github.com/briza-insurance/illogical/actions?branch=master)
-[![npm version](https://badge.fury.io/js/@briza%2Fillogical.svg?icon=si%3Anpm)](https://badge.fury.io/js/@briza%2Fillogical)
-[![install size](https://packagephobia.com/badge?p=@briza/illogical)](https://packagephobia.com/result?p=@briza/illogical)
-![zero dependencies](https://img.shields.io/badge/0-dependencies-green)
-![npm downloads](https://img.shields.io/npm/dm/%40briza%2Fillogical)
-
 </div>
 
 <div align="center">
-<p>
-<br />
-JSON DSL for expressing and evaluating business rules. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
-</p>
+  <p>
+  **illogical** is a JSON DSL (domain-specific language) for expressing and evaluating business rules in the insurance industry. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
+  </p>
+</div>
+
+<div align="center">
+  [![build status](https://github.com/briza-insurance/illogical/actions/workflows/test.yml/badge.svg)](https://github.com/briza-insurance/illogical/actions?branch=master)
+  [![npm version](https://badge.fury.io/js/@briza%2Fillogical.svg?icon=si%3Anpm)](https://badge.fury.io/js/@briza%2Fillogical)
+  [![install size](https://packagephobia.com/badge?p=@briza/illogical)](https://packagephobia.com/result?p=@briza/illogical)
+  ![zero dependencies](https://img.shields.io/badge/0-dependencies-green)
+  ![npm downloads](https://img.shields.io/npm/dm/%40briza%2Fillogical)
 </div>
 
 ---
 
-This project is designed such that business rules can be shared between the front-end and back-end, serialized in JSON.
+## 🚀 Getting Started
 
-## 🚀 Get Started
+Get up and running with illogical in just a few steps.
+
+### Installation
 
 ```sh
 # install illogical
 npm install @briza/illogical
 ```
+
+### Basic Usage
 
 ```js
 // Import the illogical engine
@@ -65,9 +69,11 @@ engine.evaluate(['==', '$age.(String)', '21'], ctx) // true
 engine.evaluate(['AND', ['>', '$age', 20], ['==', '$name', 'peter']]) // true
 ```
 
-## 🖼️ Resources
+## 📚 Documentation
 
-Understand supported expressions:
+### Core Concepts
+
+Explore the supported expressions and their usage:
 
 - [Comparison Expressions](./specs/comparison-expressions.md)
 - [Logical Expressions](./specs/logical-expressions.md)
@@ -75,19 +81,25 @@ Understand supported expressions:
 - [Evaluation Data Context](./specs/evaluation-data-context.md)
 - [Operand Types](./specs/operand-types.md)
 
-Learn about usages:
+### API Reference
+
+Learn how to use the engine and its methods:
 
 - [Evaluate](./specs/evaluate.md)
 - [Statement](./specs/statement.md)
 - [Parse](./specs/parse.md)
 - [Simplify](./specs/simplify.md)
 
+### Customization
+
 Customize the engine and the documentation:
 
 - [Engine Options](./specs/engine.md)
 - [Code Documentation](https://briza-insurance.github.io/illogical/index.html)
 
-Bytecode evaluation and debugging tools:
+### Development Tools
+
+For advanced usage like bytecode evaluation and debugging:
 
 - [Bytecode Evaluator](./specs/bytecode-evaluator.md)
 - [Debugger Tools](./specs/debugger-tools.md)


### PR DESCRIPTION
# Description

These three pages, along with the `changelog` for which I had no change suggestions, are at the top level of the repository and are likely to be the first ones that a visiting potential user would see. That makes them a priority for this quick clean up before I start the more detailed work of standardization across the documentation.

## Changes

- `contributing.md` received only minor updates and I made sure to keep the page brief as I saw the old closed PR where a contributor attempted to expand it for a different audience and read the comments
- `code-of-conduct.md` was created six years ago and based on a much older 1.6 version of the https://www.contributor-covenant.org template. This updates it to use the latest 3.0 release, but with edits to keep it simple and straightforward.
- `readme.md` benefits from some minor restructuring, clearer headings and brief descriptions