### PR TITLE
Add style guide and template and apply

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,12 +1,12 @@
-
 # Contributor Covenant 3.0 Code of Conduct
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Our Pledge
 
 We pledge to make our community welcoming, safe, and equitable for all.
 
 We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
-
 
 ## Encouraged Behaviors
 
@@ -21,7 +21,6 @@ With these considerations in mind, we agree to behave mindfully toward each othe
 5. Gracefully giving and accepting **constructive feedback**.
 6. Committing to **repairing harm** when it occurs.
 7. Behaving in other ways that promote and sustain the **well-being of our community**.
-
 
 ## Restricted Behaviors
 
@@ -42,7 +41,6 @@ We agree to restrict the following behaviors in our community. Instances, threat
 3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
 4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
 
-
 ## Reporting an Issue
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
@@ -51,18 +49,11 @@ When an incident does occur, it is important to report it promptly. To report a 
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 
-
 ## Addressing and Repairing Harm
 
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-
-## Scope
-
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
-
 
 ## Attribution
 

--- a/docs_page_template.md
+++ b/docs_page_template.md
@@ -1,0 +1,68 @@
+# Only use H1 headings for the page title
+
+Write a short paragraph to introduce the page. The developer audience is already
+covered with the operator syntax in the documentation. However, we need a higher-level
+summary here so that underwriters can quickly get up to speed. Be concise. Be clear.
+Be direct.
+
+If the page documents several operators or options, list them as anchor links
+right after the intro, so readers can jump to a section:
+
+- [First thing](#first-thing)
+- [Second thing](#second-thing)
+
+## Use sentence case for all headings
+
+Write a sentence to introduce sections. More sentences are okay if they are
+direct and necessary.
+
+Put `code` that appears in a sentence in code format with back ticks.
+
+Code in blocks requires triple back ticks at the start and end. Tag every block
+with its language. Use `js` (not `javascript`), `json`, `ts`, or `sh`:
+
+```js
+console.log("Hello, World!");
+```
+
+### Use H3 for subsections
+
+Nest H3 headings under an H2 when a section needs parts. Don't skip levels.
+
+## State constraints and notes in a blockquote
+
+Use a blockquote for an operand-type rule, a default, or a note that qualifies
+the surrounding text:
+
+> Valid operand types: string, number, boolean.
+
+## Show structured data in a table
+
+Use a table for keyed pairs, such as options, key bindings, or named cases:
+I'
+| Option | Description |
+|--------|-------------|
+| `name` | What it does |
+
+## Document an API method with a signature line
+
+For a method, lead with a signature line that mixes code font and cross-page
+links, then show an example:
+
+`engine.method(`[Argument](./other-page.md)`)` => `returnType`
+
+```js
+engine.method(['==', 5, 5]) // true
+```
+
+Label sub-parts of a method in bold when they need calling out:
+
+**Return value:**
+
+- `true` = the thing happened
+- `false` = it didn't
+
+## Link to other pages with descriptive text
+
+Link with words that name the target, not "click here": see
+[evaluation data context](./evaluation-data-context.md).

--- a/docs_page_template.md
+++ b/docs_page_template.md
@@ -39,7 +39,7 @@ the surrounding text:
 ## Show structured data in a table
 
 Use a table for keyed pairs, such as options, key bindings, or named cases:
-I'
+
 | Option | Description |
 |--------|-------------|
 | `name` | What it does |

--- a/docs_style.md
+++ b/docs_style.md
@@ -1,0 +1,35 @@
+## Documentation style for illogical
+
+Documentation in this repository follows the [Google developer documentation style guide](https://developers.google.com/style). This file lists some of the the highlights with links to learn more.
+
+Use the [docs page template](./docs_page_template.md) when creating new content pages
+and to evaluate existing content.
+
+### Tone and content
+
+- [Be conversational and friendly](https://developers.google.com/style/tone) without being frivolous.
+- [Don't pre-announce anything](https://developers.google.com/style/future) in documentation.
+- [Use descriptive link text](https://developers.google.com/style/cross-references#descriptive-link-text).
+- [Write accessibly](https://developers.google.com/style/accessibility).
+- [Write for a global audience](https://developers.google.com/style/translation).
+- [Be prescriptive](https://developers.google.com/style/prescriptive-documentation) and tell readers what to do so they are successful.
+
+### Language and grammar
+
+- [Use second person](https://developers.google.com/style/person): "you" rather than "we."
+- [Use active voice](https://developers.google.com/style/voice): make clear who's performing the action.
+- [Use standard American spelling](https://developers.google.com/style/spelling) and punctuation.
+- [Put conditions before instructions](https://developers.google.com/style/sentence-structure), not after.
+- [For usage and spelling of specific words, see the word list](https://developers.google.com/style/wordlist).
+
+### Formatting, punctuation, and organization
+
+- [Text formatting summary](https://developers.google.com/style/text-formatting) provides a quick reference.
+- [Use sentence case](https://developers.google.com/style/capitalization) for document titles and section headings.
+- [Use numbered lists](https://developers.google.com/style/lists#types-of-lists) for sequences.
+- [Use bulleted lists](https://developers.google.com/style/lists#types-of-lists) for most other lists.
+- [Use description lists](https://developers.google.com/style/lists#types-of-lists) for pairs of related pieces of data.
+- [Use serial commas](https://developers.google.com/style/commas-serial).
+- [Put code-related text in code font](https://developers.google.com/style/code-in-text).
+- [Put UI elements in bold](https://developers.google.com/style/ui-elements).
+- [Use unambiguous date formatting](https://developers.google.com/style/dates-times).

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
   </div>
 
   <p>
-  <em>illogical</em> is a JSON DSL (domain-specific language) for expressing and evaluating business rules in the insurance industry. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
+  <strong>illogical</strong> is a JSON DSL (domain-specific language) for expressing and evaluating business rules in the insurance industry. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
   </p>
 
   [![build status](https://github.com/briza-insurance/illogical/actions/workflows/test.yml/badge.svg)](https://github.com/briza-insurance/illogical/actions?branch=master)

--- a/readme.md
+++ b/readme.md
@@ -8,19 +8,17 @@
   <div align="center">
     <h3 align="center">illogical</h3>
   </div>
-</div>
 
-<div align="center">
   <p>
-  **illogical** is a JSON DSL (domain-specific language) for expressing and evaluating business rules in the insurance industry. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
+  <em>illogical</em> is a JSON DSL (domain-specific language) for expressing and evaluating business rules in the insurance industry. Underwriters use illogical to model business rules for their question sets, enabling distributors to render great user experiences.
   </p>
-</div>
 
   [![build status](https://github.com/briza-insurance/illogical/actions/workflows/test.yml/badge.svg)](https://github.com/briza-insurance/illogical/actions?branch=master)
   [![npm version](https://badge.fury.io/js/@briza%2Fillogical.svg?icon=si%3Anpm)](https://badge.fury.io/js/@briza%2Fillogical)
   [![install size](https://packagephobia.com/badge?p=@briza/illogical)](https://packagephobia.com/result?p=@briza/illogical)
   ![zero dependencies](https://img.shields.io/badge/0-dependencies-green)
   ![npm downloads](https://img.shields.io/npm/dm/%40briza%2Fillogical)
+</div>
 
 ---
 


### PR DESCRIPTION
# Description

- Added a docs style guide (`docs_style.md`) and template (`docs_page_template.md`).
- Moved a paragraph in the code of conduct from low in the page to serve as the introduction, thereby making it fit the style guide.
- Checked the other pages I edited previously to see if further edits were needed to make them conform to the new style guide, but they are fine.

Starting next I will begin editing the 12 pages in the `specs` directory. When I do, I will add an introductory paragraph to each to match the docs page template and begin to expand accessibility to a new audience, underwriters.