### PR TITLE
Finish the copy edit of the 12 specs pages

### DIFF
--- a/specs/debugger-tools.md
+++ b/specs/debugger-tools.md
@@ -1,7 +1,10 @@
 # Debugger Tools
 
 illogical includes developer tooling for debugging bytecode execution and inspecting compiled
-output.
+output. This includes:
+
+- [Bytecode disassembler](#bytecode-disassembler--get-bytecode)
+- [Time-travel debugger](#time-travel-debugger--debug-bytecode)
 
 ## Bytecode Disassembler — `get-bytecode`
 

--- a/specs/engine.md
+++ b/specs/engine.md
@@ -1,6 +1,6 @@
-# Engine Options
+# Engine options
 
-Below described, are individual options object properties which could be used individually. Any missing options will be substituted with the default options.
+The options on this page are available to you when you use the illogical engine. These options are object properties. You can use them individually. If you do not set a property, then the engine will use the default option for that property.
 
 **Usage**
 
@@ -15,9 +15,9 @@ const opts = {
 const engine = new Engine(opts)
 ```
 
-## Reference Predicate
+## Reference predicate
 
-A function used to determine if the operand is a reference type, otherwise evaluated as a static value.
+Determines whether the operand is a reference type. Predicate functions in general determine whether something is true or false and so they return a boolean response. If this reference predicate function determines the operand is not a reference type, the operand is evaluated as a static value.
 
 ```typescript
 referencePredicate: (operand: string) => boolean
@@ -30,22 +30,22 @@ referencePredicate: (operand: string) => boolean
 
 **Default reference predicate:**
 
-> The `$` symbol at the begging of the operand is used to predicate the reference type., E.g. `$State`, `$Country`.
+> The `$` symbol is used as a prefix to an operand name that indicates the reference type, for example `$state` or `$country`. See [Operand types](./operand-types.md) to learn more.
 
-## Reference Transform
+## Reference transform
 
-A function used to transform the operand into the reference annotation stripped form. I.e. remove any annotation used to detect the reference type. E.g. "$Reference" => "Reference".
+Transforms the operand into the reference annotation stripped form by removing any annotation used to detect the reference type. For example, changes "$reference" => "reference".
 
 ```typescript
 referenceTransform: (operand: string) => string
 ```
 
 > **Default reference transform:**
-> It removes the `$` symbol at the begging of the operand name.
+> This transform just removes the `$` symbol from the beginning of the operand name.
 
 ## Operator Mapping
 
-Mapping of the operators. The key is unique operator key, and the value is the key used to represent the given operator in the raw expression.
+This is a map of the operators. The key is the unique operator key, and the value is what is used to represent the given operator in a raw expression.
 
 ```typescript
 operatorMapping: Map<symbol, string>
@@ -81,7 +81,7 @@ operatorMapping: Map<symbol, string>
   [OPERATOR_DIVIDE, '/'],
 ```
 
-> The operator keys are unique symbols which could be imported from the engine package:
+> The operator keys are unique symbols which can be imported from the engine package, like this:
 
 ```js
 import {

--- a/specs/evaluate.md
+++ b/specs/evaluate.md
@@ -1,6 +1,6 @@
 # Evaluate
 
-Evaluate comparison or logical expression as TRUE or FALSE result:
+Evaluates a comparison or logical expression. Returns TRUE or FALSE.
 
 `engine.evaluate(`[Comparison Expression](./comparison-expressions.md) or [Logical Expression](./logical-expressions.md), [Evaluation Data Context](./evaluation-data-context.md)`)` => `boolean`
 

--- a/specs/evaluation-data-context.md
+++ b/specs/evaluation-data-context.md
@@ -1,13 +1,13 @@
-# Evaluation Data Context
+# Evaluation data context
 
-The evaluation data context is used to provide the expression with variable references, i.e. this allows for the dynamic expressions. The data context is object with properties used as the references keys, and its values as reference values.
+The evaluation data context is used to provide the expression with variable references. This enables dynamic expressions. The data context is an object with properties used as the reference keys, and object values as reference values.
 
 > Valid reference values: object, string, number, boolean, string[], number[].
 
-To reference the nested reference, please use "." delimiter, e.g.:
+To reference the nested reference, use the "." delimiter:
 `$address.city`
 
-If the key of the nested reference includes the "." delimiter, please wrap the whole key with backticks `` ` ``, e.g.:
+If the key of the nested reference includes the "." delimiter, wrap the entire key with backticks `` ` ``:
 `` $address.`city.code` `` can reference the object
 
 ```javascript
@@ -18,7 +18,7 @@ If the key of the nested reference includes the "." delimiter, please wrap the w
 }
 ```
 
-``$address.`city.code`[0]`` can reference the object
+``$address.`city.code`[0]`` can reference the object when the value of the nested reference is an array, like this:
 
 ```javascript
 {
@@ -28,25 +28,23 @@ If the key of the nested reference includes the "." delimiter, please wrap the w
 }
 ```
 
-when the value of the nested reference is an array.
-
-## Accessing Array Element
+## Accessing array element
 
 `$options[1]`
 
-## Accessing Array Element via Reference
+## Accessing array element via reference
 
 `$options[{index}]`
 
 - The **index** reference is resolved within the data context as an array index.
 
-## Nested Referencing
+## Nested referencing
 
 `$address.{segment}`
 
 - The **segment** reference is resolved within the data context as a property key.
 
-## Composite Reference Key
+## Composite reference key
 
 `$shape{shapeType}`
 
@@ -54,13 +52,13 @@ when the value of the nested reference is an array.
 - E.g. **shapeType** is resolved as "**B**" and would compose the **$shapeB** outer reference.
 - This resolution could be n-nested.
 
-## Data Type Casting
+## Data type casting
 
 `$payment.amount.(Type)`
 
 Cast the given data context into the desired data type before being used as an operand in the evaluation.
 
-> Note: If the conversion is invalid, then a warning message is being logged.
+> Note: If the conversion is invalid, then a warning message is logged.
 
 Supported data type conversions:
 

--- a/specs/logical-expressions.md
+++ b/specs/logical-expressions.md
@@ -1,4 +1,8 @@
-# Logical Expressions
+# Logical expressions
+
+A logical expression is a programming statement that evaluates the relationship
+between two values. The expression will return a binary Boolean result. Think of
+these like asking a true or false question, such as "Are both of these two values true?"
 
 - [And](#and)
 - [Or](#or)
@@ -56,7 +60,7 @@ engine.evaluate(['NOR', ['==', 5, 1], ['==', 10, 5]]) // true
 
 ## Xor
 
-The logical NOR operator returns the boolean value TRUE if both operands are FALSE and returns FALSE otherwise.
+The logical XOR operator returns the boolean value TRUE if exactly one of the operands is TRUE and returns FALSE otherwise.
 
 Expression format: `["XOR", Left Operand 1, Right Operand 2, ... , Right Operand N]`
 

--- a/specs/operand-types.md
+++ b/specs/operand-types.md
@@ -1,10 +1,13 @@
-# Operand Types
+# Operand types
 
-The [Comparison Expression](./comparison-expressions.md) expect operands to be one of the below:
+The [Comparison Expression](./comparison-expressions.md) expect operands to be one of the following:
+- [Value](#value)
+- [Reference](#reference)
+- [Collection](#collection)
 
 ## Value
 
-Simple value types: string, number, boolean.
+Value operands are one of these simple types: string, number, boolean.
 
 ```js
 ;['==', 5, 5][('==', 'circle', 'circle')][('==', true, true)]
@@ -14,7 +17,7 @@ Simple value types: string, number, boolean.
 
 The reference operand value is resolved from the [Evaluation Data Context](./evaluation-data-context.md), where the operands name is used as key in the context.
 
-The reference operand must be prefixed with `$` symbol, e.g.: `$name`. This can be customized via [Reference Predicate Parser Option](./engine.md#reference-predicate).
+The reference operand must be prefixed with the `$` symbol, as in `$name`. This can be customized via [Reference Predicate Parser Option](./engine.md#reference-predicate).
 
 | Expression                    | Data Context                          |
 | ----------------------------- | ------------------------------------- |
@@ -25,7 +28,7 @@ The reference operand must be prefixed with `$` symbol, e.g.: `$name`. This can 
 
 ## Collection
 
-The operand could be an array mixed from [Value](#value) and [Reference](#reference).
+The operand is be an array and can be mixed from [Value](#value) and [Reference](#reference).
 
 | Expression                                 | Data Context                        |
 | ------------------------------------------ | ----------------------------------- |

--- a/specs/parse.md
+++ b/specs/parse.md
@@ -1,6 +1,6 @@
 # Parse
 
-Parse the expression into a evaluable object, i.e. it returns the parsed self-evaluable condition expression.
+Parse the expression into a evaluable object. When used, it returns the parsed self-evaluable condition expression.
 
 `engine.parse(`[Comparison Expression](./comparison-expressions.md) or [Logical Expression](./logical-expressions.md)`)` => `evaluable`
 

--- a/specs/simplify.md
+++ b/specs/simplify.md
@@ -1,7 +1,7 @@
 # Simplify
 
 Simplifies an expression with a given context. This is useful when you already have some of
-the properties of context and wants to try to evaluate the expression.
+the properties of context and want to try to evaluate the expression.
 
 ```js
 engine.simplify(['AND', ['==', '$a', 10], ['==', '$b', 20]], { a: 10 }) // ['==', '$b', 20]

--- a/specs/statement.md
+++ b/specs/statement.md
@@ -1,6 +1,6 @@
 # Statement
 
-Get expression string representation:
+Returns the expression string representation:
 
 `engine.statement(`[Comparison Expression](./comparison-expressions.md) or [Logical Expression](./logical-expressions.md)`)` => `string`
 


### PR DESCRIPTION
# Description

This continues my copy edit of the docs by completing the edit pass across all of the remaining specs pages.

The goal of the next PR will be to reorganize the specs under a clear navigation hub, grouped by purpose:
- expression types
- usage
- configuration
- advanced

That should make it more immediately obvious which page a reader needs for the task they have in mind.