### PR TITLE
Add note on non-present operands for arithmetic expressions

### DIFF
--- a/specs/arithmetic-expressions.md
+++ b/specs/arithmetic-expressions.md
@@ -9,7 +9,7 @@ An arithmetic expression combines numeric values, variables, and arithmetic oper
 
 Arithmetic Expressions are not supported as root level expressions since those must evaluate to a boolean. But arithmetic expressions can be used nested within [Comparisson Expressions](./comparison-expressions.md).
 
-> Note: Any non-present operand is discarded. This means that if a reference is missing, the expression will return FALSE. Also, all operands that ARE present must be numbers, otherwise an error is thrown.
+> Note: Any non-present operand is discarded. This means that if a reference is missing, the expression will return FALSE. Also, all operands that ARE present must be either numbers or an ISO date string followed by valid date durations, otherwise an error is thrown.
 
 ## Division
 

--- a/specs/arithmetic-expressions.md
+++ b/specs/arithmetic-expressions.md
@@ -9,6 +9,8 @@ An arithmetic expression combines numeric values, variables, and arithmetic oper
 
 Arithmetic Expressions are not supported as root level expressions since those must evaluate to a boolean. But arithmetic expressions can be used nested within [Comparisson Expressions](./comparison-expressions.md).
 
+> Note: Any non-present operand is discarded. This means that if a reference is missing, the expression will return FALSE. Also, all operands that ARE present must be numbers, otherwise an error is thrown.
+
 ## Division
 
 The arithmetical operator for division calculates how many times one number is contained within another number. The expression denotes the left-most operand as the dividend (the number being divided up) and the subsequent operand as the divisor (the number that we're attempting to repeatedly contain in the dividend).


### PR DESCRIPTION
# Description

Added a note that covers when an arithmetic expression has a missing operand. Before we merge, do we want to add anything that covers the "weird" edge case where evaluating `["==",["+","$Ref1",0],["+",0,"$Ref2",0]]` with an empty context results in TRUE (because both arithmetic expressions result in FALSE due to both refs being absent)?

I added content to cover the main case. For this edge case, we would also want to note that it is possible to overcome the expected behavior by appending PRESENT expressions on each Ref merging with an AND.

But, 1) how likely is this and 2) how detailed do we want to go with edge cases? I'm here and willing, but is it worth what my time costs? I'm not a good judge of that (because I'm really happy for you to pay for my time).

@atoledo please ping me if you think it's worth a quick video chat and I'm happy to schedule one!!