### PR TITLE
Fix bytecode OOP mismatch on multi-operand arithmetic with missing refs

### DIFF
--- a/conditions/evaluate-conditions/99-multiply-missing-ref-both.json
+++ b/conditions/evaluate-conditions/99-multiply-missing-ref-both.json
@@ -1,0 +1,1 @@
+{"description":"Arithmetic 4-operand multiply missing refs both sides => true","expression":["==",["*",1,2,"$A"],["*","$B",3,4,5]],"context":{},"expected":true}

--- a/conditions/evaluate-conditions/99-subtract-missing-ref-both.json
+++ b/conditions/evaluate-conditions/99-subtract-missing-ref-both.json
@@ -1,0 +1,1 @@
+{"description":"Arithmetic 3-operand subtract missing ref both sides => true","expression":["==",["-",10,"$A"],["-","$B",1,2]],"context":{},"expected":true}

--- a/conditions/evaluate-conditions/99-sum-missing-ref-both.json
+++ b/conditions/evaluate-conditions/99-sum-missing-ref-both.json
@@ -1,0 +1,1 @@
+{"description":"Arithmetic 3-operand sums missing refs both sides => true","expression":["==",["+",1,"$A",2],["+",1,2,"$B"]],"context":{},"expected":true}

--- a/conditions/evaluate-conditions/99-sum-missing-ref-mismatch.json
+++ b/conditions/evaluate-conditions/99-sum-missing-ref-mismatch.json
@@ -1,0 +1,1 @@
+{"description":"Arithmetic 3-operand sum missing middle ref: ==(missing-ref sum, concrete), (missing middle-ref sum) with {} => true","expression":["==",["+","$A",0],["+",0,"$0",0]],"context":{},"expected":true}

--- a/conditions/evaluate-conditions/99-sum-missing-ref-vs-number.json
+++ b/conditions/evaluate-conditions/99-sum-missing-ref-vs-number.json
@@ -1,0 +1,1 @@
+{"description":"Arithmetic 3-operand sum missing ref vs concrete number => false","expression":["==",["+","$A",1,2],["+",1,2,3]],"context":{},"expected":false}

--- a/src/__test__/unit/bytecode-arithmetic-stack.test.ts
+++ b/src/__test__/unit/bytecode-arithmetic-stack.test.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+
+import Engine, { type Context, type ExpressionInput } from '../../index.js'
+
+/**
+ * Regression tests for a bytecode OOP evaluation mismatch on multi-operand
+ * (3+) arithmetic expressions containing missing references.
+ *
+ * Reported case:
+ *   evaluate ["==",["+","$A",0],["+",0,"$0",0]] with {}
+ *     OOP          -> true
+ *     bytecode     -> false   (mismatch)
+ *
+ * The documented behavior is that arithmetic ignores non-present operands for
+ * the calculation but returns false if any reference is missing. Both operands
+ * here evaluate to false, so `false == false` is true.
+ *
+ * Every case must evaluate identically under both the `oop` and `bytecode`
+ * evaluators.
+ */
+
+interface Case {
+  description: string
+  expression: ExpressionInput
+  context: Context
+  expected: boolean
+}
+
+const CASES: Case[] = [
+  {
+    description:
+      'reported: ==(missing-ref sum, concrete), (missing middle-ref sum) with {}',
+    expression: ['==', ['+', '$A', 0], ['+', 0, '$0', 0]],
+    context: {},
+    expected: true, // false == false
+  },
+  {
+    description: '3-operand sums with missing refs on both sides',
+    expression: ['==', ['+', 1, '$A', 2], ['+', 1, 2, '$B']],
+    context: {},
+    expected: true, // false == false
+  },
+  {
+    description:
+      '3-operand sum missing ref vs a concrete sum (false == number)',
+    expression: ['==', ['+', '$A', 1, 2], ['+', 1, 2, 3]],
+    context: {},
+    expected: false, // false == 6
+  },
+  {
+    description: '3-operand subtract with a missing ref on both sides',
+    expression: ['==', ['-', 10, '$A'], ['-', '$B', 1, 2]],
+    context: {},
+    expected: true, // false == false
+  },
+  {
+    description: '4-operand multiply with a missing ref on both sides',
+    expression: ['==', ['*', 1, 2, '$A'], ['*', '$B', 3, 4, 5]],
+    context: {},
+    expected: true, // false == false
+  },
+  {
+    description: '4-operand sum present matches a concrete 2-operand sum',
+    expression: ['==', ['+', 1, 2, 3, 4], ['+', 3, 7]],
+    context: {},
+    expected: true, // 10 == 10
+  },
+  {
+    description: '3-operand sum present with an actual context value',
+    expression: ['==', ['+', '$X', 1, 2], 10],
+    context: { X: 7 },
+    expected: true, // 10 == 10
+  },
+]
+
+const oop = new Engine({ evaluator: 'oop' })
+const bytecode = new Engine({ evaluator: 'bytecode' })
+
+for (const tc of CASES) {
+  test(`oop: ${tc.description}`, () => {
+    assert.strictEqual(
+      oop.evaluate(tc.expression, tc.context),
+      tc.expected,
+      `Expected ${tc.expected}, got ${oop.evaluate(tc.expression, tc.context)}`
+    )
+  })
+
+  test(`bytecode: ${tc.description}`, () => {
+    assert.strictEqual(
+      bytecode.evaluate(tc.expression, tc.context),
+      tc.expected,
+      `Expected ${tc.expected}, got ${bytecode.evaluate(tc.expression, tc.context)}`
+    )
+  })
+
+  test(`agreement: ${tc.description}`, () => {
+    const a = oop.evaluate(tc.expression, tc.context)
+    const b = bytecode.evaluate(tc.expression, tc.context)
+    assert.strictEqual(
+      a,
+      b,
+      `Evaluators disagree on ${JSON.stringify(tc.expression)} with ${JSON.stringify(
+        tc.context
+      )}: oop=${a}, bytecode=${b}`
+    )
+  })
+}

--- a/src/bytecode/interpreter.ts
+++ b/src/bytecode/interpreter.ts
@@ -512,7 +512,8 @@ export function interpret(compiled: CompiledExpression, ctx: Context): Result {
       }
 
       case OP_OR_AND_IN_CONST_2: {
-        // bytecode layout: ref1Idx, ref2Idx, M, (v0, setBIdx0, ref1Op0, ref2Op0), (v1, setBIdx1, ref1Op1, ref2Op1), ...
+        // bytecode layout: ref1Idx, ref2Idx, M,
+        //   (aVal0, setBIdx0, ref1Op0, ref2Op0), (aVal1, setBIdx1, ref1Op1, ref2Op1), ...
         // ref1Op/ref2Op: 0 for 'eq', 1 for 'in' (unused at runtime, kept for simplifier)
         // constSets[setBIdx] is pre-built at first interpret() call — plain Set.has lookup.
         const ref1Idx = numAt(bytecode[++i])
@@ -669,9 +670,15 @@ export function interpret(compiled: CompiledExpression, ctx: Context): Result {
           break
         }
         const values: Array<string | number> = new Array(n)
+        // Fixed destination slot for the single result value: the bottom-most
+        // operand slot. The operands occupy [stackTop - n + 1 .. stackTop].
+        // Writing here (instead of to stack[++stackTop]) keeps the result in a
+        // stable slot even when the loop below breaks early on a missing
+        // operand, so the next opcode never reads a stale operand value.
+        const resultSlot = stackTop - n + 1
         let hasNull = false
         const isDateArithmetic =
-          !isNaN(toDateNumber(stack[stackTop - n + 1])) &&
+          !isNaN(toDateNumber(stack[resultSlot])) &&
           (op === OP_SUM || op === OP_SUBTRACT)
         for (let j = n - 1; j >= 0; j--) {
           const v = stack[stackTop--]
@@ -695,7 +702,7 @@ export function interpret(compiled: CompiledExpression, ctx: Context): Result {
             values[j] = v
           }
         }
-        stack[++stackTop] = hasNull
+        const result = hasNull
           ? false
           : isDateArithmetic &&
               (op === OP_SUM || op === OP_SUBTRACT) &&
@@ -704,6 +711,8 @@ export function interpret(compiled: CompiledExpression, ctx: Context): Result {
             : values.every((v) => isNumber(v))
               ? arithmeticReduce(values, op)
               : false
+        stack[resultSlot] = result
+        stackTop = resultSlot
         break
       }
 


### PR DESCRIPTION
Multi-operand SUM/SUBTRACT (3+ operands) with missing refs produced a different result in bytecode than the OOP evaluator. The multi-operand path wrote to the wrong stack slot; now it writes to the operand slot and resets the stack top, matching OOP. Adds regression tests + sample conditions.
