### PR TITLE
Fix bytecode simplify dropping operands in nested OR/AND composition

### DIFF
--- a/benchmark/report-sample-evaluate.md
+++ b/benchmark/report-sample-evaluate.md
@@ -6,11 +6,11 @@
 
 ## Summary
 
-|               | Count |
-| ------------- | ----- |
-| Faster (>+5%) | 788   |
-| Slower (>-5%) | 3     |
-| Unchanged     | 1     |
+| | Count |
+|---|---|
+| Faster (>+5%) | 787 |
+| Slower (>-5%) | 3 |
+| Unchanged | 2 |
 
 ---
 
@@ -18,58 +18,59 @@
 
 ### Top 20 Most Improved
 
-| Group                 | Case                 | Baseline      | Improved     | Delta     | Multiplier |
-| --------------------- | -------------------- | ------------- | ------------ | --------- | ---------- |
-| or-n4691-r2-001       | full-execution-false | 57.47K ops/s  | 13.01M ops/s | +22536.6% | 226.37x    |
-| or-n4691-r2-001       | full-execution-true  | 58.28K ops/s  | 12.38M ops/s | +21148.0% | 212.48x    |
-| or-n4691-r2-001       | late-true            | 59.04K ops/s  | 12.07M ops/s | +20344.4% | 204.44x    |
-| or-n4691-r2-001       | empty-context        | 102.43K ops/s | 18.14M ops/s | +17609.2% | 177.09x    |
-| or-n4691-r2-001       | partial-false        | 101.45K ops/s | 17.36M ops/s | +17007.4% | 171.07x    |
-| or-n4691-r2-001       | complete-false       | 70.97K ops/s  | 8.51M ops/s  | +11891.3% | 119.91x    |
-| or-n3412-r101-001     | early-true           | 104.61K ops/s | 11.63M ops/s | +11022.3% | 111.22x    |
-| or-n3412-r101-001     | complete-true        | 109.07K ops/s | 11.73M ops/s | +10656.5% | 107.57x    |
-| or-n3412-r101-001     | partial-true         | 113.26K ops/s | 11.97M ops/s | +10468.5% | 105.69x    |
-| or-n1968-r105-001     | complete-true        | 136.74K ops/s | 11.13M ops/s | +8040.7%  | 81.41x     |
-| or-n1968-r105-001     | early-true           | 146.02K ops/s | 11.32M ops/s | +7654.0%  | 77.54x     |
-| or-n1968-r105-001     | partial-true         | 158.99K ops/s | 11.53M ops/s | +7150.0%  | 72.50x     |
-| overlap-n105-r100-012 | complete-true        | 287.93K ops/s | 19.13M ops/s | +6542.9%  | 66.43x     |
-| overlap-n105-r100-004 | full-execution-true  | 314.38K ops/s | 19.49M ops/s | +6099.2%  | 61.99x     |
-| overlap-n105-r100-011 | complete-true        | 319.18K ops/s | 19.68M ops/s | +6065.2%  | 61.65x     |
-| overlap-n105-r100-011 | early-true           | 320.95K ops/s | 19.72M ops/s | +6043.2%  | 61.43x     |
-| overlap-n105-r100-007 | complete-true        | 315.07K ops/s | 19.22M ops/s | +6000.3%  | 61.00x     |
-| overlap-n105-r100-008 | early-true           | 319.53K ops/s | 19.49M ops/s | +5999.7%  | 61.00x     |
-| overlap-n105-r100-012 | early-true           | 318.57K ops/s | 19.35M ops/s | +5973.1%  | 60.73x     |
-| overlap-n105-r100-021 | complete-true        | 316.69K ops/s | 19.15M ops/s | +5946.3%  | 60.46x     |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| or-n4691-r2-001 | full-execution-false | 60.18K ops/s | 12.96M ops/s | +21439.3% | 215.39x |
+| or-n4691-r2-001 | full-execution-true | 60.34K ops/s | 12.33M ops/s | +20337.1% | 204.37x |
+| or-n4691-r2-001 | late-true | 60.50K ops/s | 12.32M ops/s | +20255.8% | 203.56x |
+| or-n4691-r2-001 | empty-context | 106.90K ops/s | 17.39M ops/s | +16170.3% | 162.70x |
+| or-n4691-r2-001 | partial-false | 105.35K ops/s | 17.02M ops/s | +16053.3% | 161.53x |
+| or-n3412-r101-001 | early-true | 98.20K ops/s | 11.38M ops/s | +11487.5% | 115.88x |
+| or-n3412-r101-001 | complete-true | 110.07K ops/s | 11.95M ops/s | +10755.4% | 108.55x |
+| or-n4691-r2-001 | complete-false | 82.32K ops/s | 8.53M ops/s | +10258.9% | 103.59x |
+| or-n3412-r101-001 | partial-true | 119.37K ops/s | 11.36M ops/s | +9416.2% | 95.16x |
+| or-n1968-r105-001 | complete-true | 149.72K ops/s | 11.63M ops/s | +7670.5% | 77.71x |
+| or-n1968-r105-001 | early-true | 151.46K ops/s | 11.24M ops/s | +7321.5% | 74.22x |
+| or-n1968-r105-001 | partial-true | 168.08K ops/s | 11.97M ops/s | +7023.4% | 71.23x |
+| overlap-n105-r100-004 | complete-true | 347.86K ops/s | 20.83M ops/s | +5888.8% | 59.89x |
+| overlap-n105-r100-014 | complete-true | 349.08K ops/s | 20.88M ops/s | +5881.1% | 59.81x |
+| overlap-n105-r100-021 | complete-true | 347.91K ops/s | 20.81M ops/s | +5880.1% | 59.80x |
+| overlap-n105-r100-001 | full-execution-true | 346.24K ops/s | 20.62M ops/s | +5854.9% | 59.55x |
+| overlap-n105-r100-004 | full-execution-true | 349.37K ops/s | 20.74M ops/s | +5835.6% | 59.36x |
+| overlap-n105-r100-008 | full-execution-true | 349.27K ops/s | 20.60M ops/s | +5797.1% | 58.97x |
+| overlap-n105-r100-012 | full-execution-true | 346.77K ops/s | 20.38M ops/s | +5777.8% | 58.78x |
+| overlap-n105-r100-001 | complete-true | 349.21K ops/s | 20.42M ops/s | +5746.5% | 58.46x |
 
 ### Top 20 Least Improved
 
-| Group                     | Case                 | Baseline      | Improved      | Delta  | Multiplier |
-| ------------------------- | -------------------- | ------------- | ------------- | ------ | ---------- |
-| 249-and-or-eqs            | complete-false       | 17.28M ops/s  | 11.40M ops/s  | -34.0% | 0.66x      |
-| 249-and-or-eqs            | empty-context        | 16.56M ops/s  | 11.86M ops/s  | -28.4% | 0.72x      |
-| 249-and-or-eqs            | partial-false        | 15.73M ops/s  | 11.61M ops/s  | -26.2% | 0.74x      |
-| 249-and-or-eqs            | complete-true        | 6.21M ops/s   | 6.46M ops/s   | +4.1%  | 1.04x      |
-| 249-and-or-eqs            | partial-true         | 5.94M ops/s   | 6.84M ops/s   | +15.2% | 1.15x      |
-| 249-and-or-eqs            | early-true           | 5.91M ops/s   | 6.82M ops/s   | +15.4% | 1.15x      |
-| 251-or-and-in-mixed-eq-in | partial-true         | 12.01M ops/s  | 16.84M ops/s  | +40.2% | 1.40x      |
-| 250-or-and-in             | complete-true        | 11.71M ops/s  | 16.52M ops/s  | +41.0% | 1.41x      |
-| 251-or-and-in-mixed-eq-in | early-true           | 11.64M ops/s  | 16.54M ops/s  | +42.0% | 1.42x      |
-| 250-or-and-in             | early-true           | 11.37M ops/s  | 16.15M ops/s  | +42.1% | 1.42x      |
-| 251-or-and-in-mixed-eq-in | complete-true        | 11.72M ops/s  | 16.75M ops/s  | +42.9% | 1.43x      |
-| 250-or-and-in             | partial-true         | 11.55M ops/s  | 16.71M ops/s  | +44.7% | 1.45x      |
-| 249-and-or-eqs            | late-true            | 4.41M ops/s   | 6.85M ops/s   | +55.4% | 1.55x      |
-| overlap-n108-r100-002     | complete-false       | 304.80K ops/s | 492.98K ops/s | +61.7% | 1.62x      |
-| overlap-n108-r100-002     | full-execution-false | 301.33K ops/s | 491.37K ops/s | +63.1% | 1.63x      |
-| 249-and-or-eqs            | full-execution-false | 4.21M ops/s   | 6.92M ops/s   | +64.3% | 1.64x      |
-| overlap-n107-r100-001     | full-execution-false | 310.55K ops/s | 511.65K ops/s | +64.8% | 1.65x      |
-| overlap-n105-r100-006     | complete-false       | 305.61K ops/s | 506.04K ops/s | +65.6% | 1.66x      |
-| overlap-n107-r100-001     | complete-false       | 310.17K ops/s | 516.55K ops/s | +66.5% | 1.67x      |
-| 250-or-and-in             | empty-context        | 11.33M ops/s  | 18.94M ops/s  | +67.1% | 1.67x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| 249-and-or-eqs | empty-context | 17.24M ops/s | 10.96M ops/s | -36.4% | 0.64x |
+| 249-and-or-eqs | complete-false | 17.30M ops/s | 11.10M ops/s | -35.8% | 0.64x |
+| 249-and-or-eqs | partial-false | 16.69M ops/s | 11.02M ops/s | -34.0% | 0.66x |
+| 249-and-or-eqs | partial-true | 6.32M ops/s | 6.54M ops/s | +3.5% | 1.03x |
+| 249-and-or-eqs | early-true | 6.31M ops/s | 6.61M ops/s | +4.8% | 1.05x |
+| 249-and-or-eqs | complete-true | 6.30M ops/s | 6.65M ops/s | +5.6% | 1.06x |
+| 251-or-and-in-mixed-eq-in | partial-true | 11.86M ops/s | 16.41M ops/s | +38.4% | 1.38x |
+| 250-or-and-in | partial-true | 11.81M ops/s | 16.49M ops/s | +39.7% | 1.40x |
+| 250-or-and-in | complete-true | 11.88M ops/s | 17.14M ops/s | +44.2% | 1.44x |
+| 250-or-and-in | early-true | 11.74M ops/s | 17.08M ops/s | +45.5% | 1.46x |
+| 251-or-and-in-mixed-eq-in | early-true | 11.75M ops/s | 17.15M ops/s | +46.0% | 1.46x |
+| 249-and-or-eqs | full-execution-true | 4.52M ops/s | 6.60M ops/s | +46.2% | 1.46x |
+| 249-and-or-eqs | full-execution-false | 4.50M ops/s | 6.61M ops/s | +46.9% | 1.47x |
+| 249-and-or-eqs | late-true | 4.44M ops/s | 6.55M ops/s | +47.5% | 1.48x |
+| 251-or-and-in-mixed-eq-in | complete-true | 11.64M ops/s | 17.19M ops/s | +47.7% | 1.48x |
+| overlap-n11-r5-001 | complete-false | 6.95M ops/s | 11.07M ops/s | +59.3% | 1.59x |
+| overlap-n11-r5-001 | full-execution-false | 7.03M ops/s | 11.25M ops/s | +60.0% | 1.60x |
+| 250-or-and-in | empty-context | 11.23M ops/s | 17.98M ops/s | +60.1% | 1.60x |
+| overlap-n11-r5-001 | partial-false | 6.94M ops/s | 11.33M ops/s | +63.3% | 1.63x |
+| overlap-n11-r5-001 | empty-context | 7.35M ops/s | 12.10M ops/s | +64.6% | 1.65x |
 
 ### Regressions
 
-| Group          | Case           | Baseline     | Improved     | Delta  | Multiplier |
-| -------------- | -------------- | ------------ | ------------ | ------ | ---------- |
-| 249-and-or-eqs | complete-false | 17.28M ops/s | 11.40M ops/s | -34.0% | 0.66x      |
-| 249-and-or-eqs | empty-context  | 16.56M ops/s | 11.86M ops/s | -28.4% | 0.72x      |
-| 249-and-or-eqs | partial-false  | 15.73M ops/s | 11.61M ops/s | -26.2% | 0.74x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| 249-and-or-eqs | empty-context | 17.24M ops/s | 10.96M ops/s | -36.4% | 0.64x |
+| 249-and-or-eqs | complete-false | 17.30M ops/s | 11.10M ops/s | -35.8% | 0.64x |
+| 249-and-or-eqs | partial-false | 16.69M ops/s | 11.02M ops/s | -34.0% | 0.66x |
+

--- a/benchmark/report-sample-simplify.md
+++ b/benchmark/report-sample-simplify.md
@@ -6,11 +6,11 @@
 
 ## Summary
 
-|               | Count |
-| ------------- | ----- |
-| Faster (>+5%) | 613   |
-| Slower (>-5%) | 1     |
-| Unchanged     | 2     |
+| | Count |
+|---|---|
+| Faster (>+5%) | 608 |
+| Slower (>-5%) | 2 |
+| Unchanged | 6 |
 
 ---
 
@@ -18,56 +18,58 @@
 
 ### Top 20 Most Improved
 
-| Group             | Case                 | Baseline     | Improved      | Delta     | Multiplier |
-| ----------------- | -------------------- | ------------ | ------------- | --------- | ---------- |
-| or-n4691-r2-001   | full-execution-true  | 30.16K ops/s | 9.49M ops/s   | +31365.3% | 314.65x    |
-| or-n4691-r2-001   | full-execution-false | 30.16K ops/s | 8.91M ops/s   | +29449.2% | 295.49x    |
-| or-n4691-r2-001   | complete-false       | 39.76K ops/s | 7.15M ops/s   | +17887.9% | 179.88x    |
-| or-n3412-r101-001 | full-execution-false | 4.94K ops/s  | 164.13K ops/s | +3222.9%  | 33.23x     |
-| or-n3412-r101-001 | complete-false       | 5.16K ops/s  | 158.41K ops/s | +2972.2%  | 30.72x     |
-| or-n1968-r105-001 | full-execution-false | 9.28K ops/s  | 266.37K ops/s | +2770.1%  | 28.70x     |
-| or-n1968-r105-001 | complete-false       | 9.12K ops/s  | 257.50K ops/s | +2724.5%  | 28.24x     |
-| or-n4691-r2-001   | partial-false        | 14.14K ops/s | 346.96K ops/s | +2353.4%  | 24.53x     |
-| or-n4691-r2-001   | empty-context        | 14.42K ops/s | 344.58K ops/s | +2289.7%  | 23.90x     |
-| or-n1968-r105-001 | partial-false        | 78.40K ops/s | 1.51M ops/s   | +1822.7%  | 19.23x     |
-| or-n1968-r105-001 | empty-context        | 78.08K ops/s | 1.42M ops/s   | +1723.0%  | 18.23x     |
-| or-n1968-r105-001 | partial-true         | 78.42K ops/s | 1.40M ops/s   | +1690.8%  | 17.91x     |
-| or-n3412-r101-001 | full-execution-true  | 7.50K ops/s  | 124.56K ops/s | +1560.1%  | 16.60x     |
-| or-n1968-r105-001 | full-execution-true  | 12.89K ops/s | 195.74K ops/s | +1418.4%  | 15.18x     |
-| or-n3412-r101-001 | empty-context        | 46.06K ops/s | 666.40K ops/s | +1346.8%  | 14.47x     |
-| or-n3412-r101-001 | partial-false        | 46.55K ops/s | 672.02K ops/s | +1343.7%  | 14.44x     |
-| or-n3412-r101-001 | partial-true         | 46.97K ops/s | 652.95K ops/s | +1290.2%  | 13.90x     |
-| in-n122-r1-001    | complete-false       | 1.10M ops/s  | 10.18M ops/s  | +829.3%   | 9.29x      |
-| or-n3412-r101-001 | complete-true        | 43.79K ops/s | 394.32K ops/s | +800.5%   | 9.01x      |
-| in-n122-r1-001    | full-execution-false | 1.09M ops/s  | 9.71M ops/s   | +787.2%   | 8.87x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| or-n4691-r2-001 | full-execution-true | 31.22K ops/s | 8.73M ops/s | +27872.2% | 279.72x |
+| or-n4691-r2-001 | full-execution-false | 31.70K ops/s | 8.72M ops/s | +27392.6% | 274.93x |
+| or-n4691-r2-001 | complete-false | 41.61K ops/s | 7.02M ops/s | +16781.2% | 168.81x |
+| or-n3412-r101-001 | full-execution-false | 4.95K ops/s | 173.21K ops/s | +3398.3% | 34.98x |
+| or-n3412-r101-001 | complete-false | 5.22K ops/s | 168.49K ops/s | +3127.2% | 32.27x |
+| or-n1968-r105-001 | full-execution-false | 9.33K ops/s | 255.13K ops/s | +2634.6% | 27.35x |
+| or-n1968-r105-001 | complete-false | 8.96K ops/s | 238.58K ops/s | +2562.3% | 26.62x |
+| or-n1968-r105-001 | partial-false | 74.42K ops/s | 1.54M ops/s | +1969.6% | 20.70x |
+| or-n1968-r105-001 | empty-context | 74.45K ops/s | 1.52M ops/s | +1937.0% | 20.37x |
+| or-n1968-r105-001 | partial-true | 74.81K ops/s | 1.45M ops/s | +1832.4% | 19.32x |
+| or-n4691-r2-001 | partial-false | 14.16K ops/s | 263.40K ops/s | +1759.6% | 18.60x |
+| or-n4691-r2-001 | empty-context | 14.44K ops/s | 263.92K ops/s | +1727.7% | 18.28x |
+| or-n3412-r101-001 | full-execution-true | 7.38K ops/s | 120.84K ops/s | +1536.3% | 16.36x |
+| or-n3412-r101-001 | partial-true | 42.31K ops/s | 654.05K ops/s | +1445.9% | 15.46x |
+| or-n3412-r101-001 | partial-false | 43.40K ops/s | 667.91K ops/s | +1438.8% | 15.39x |
+| or-n3412-r101-001 | empty-context | 43.93K ops/s | 670.72K ops/s | +1426.6% | 15.27x |
+| or-n1968-r105-001 | full-execution-true | 13.24K ops/s | 200.44K ops/s | +1414.1% | 15.14x |
+| or-n3412-r101-001 | complete-true | 42.45K ops/s | 404.45K ops/s | +852.7% | 9.53x |
+| in-n122-r1-001 | complete-false | 1.07M ops/s | 9.37M ops/s | +774.6% | 8.75x |
+| in-n122-r1-001 | full-execution-false | 1.09M ops/s | 9.41M ops/s | +761.2% | 8.61x |
 
 ### Top 20 Least Improved
 
-| Group                 | Case           | Baseline    | Improved    | Delta  | Multiplier |
-| --------------------- | -------------- | ----------- | ----------- | ------ | ---------- |
-| 249-and-or-eqs        | complete-false | 9.77M ops/s | 5.78M ops/s | -40.8% | 0.59x      |
-| 249-and-or-eqs        | complete-true  | 3.48M ops/s | 3.49M ops/s | +0.2%  | 1.00x      |
-| 249-and-or-eqs        | partial-true   | 3.42M ops/s | 3.49M ops/s | +2.1%  | 1.02x      |
-| overlap-n106-r100-001 | partial-false  | 7.92M ops/s | 8.50M ops/s | +7.3%  | 1.07x      |
-| overlap-n105-r100-017 | partial-false  | 8.23M ops/s | 9.31M ops/s | +13.2% | 1.13x      |
-| overlap-n105-r100-013 | partial-false  | 8.36M ops/s | 9.49M ops/s | +13.5% | 1.13x      |
-| overlap-n105-r100-006 | partial-false  | 7.98M ops/s | 9.10M ops/s | +14.0% | 1.14x      |
-| overlap-n105-r100-014 | partial-false  | 8.33M ops/s | 9.63M ops/s | +15.6% | 1.16x      |
-| overlap-n105-r100-011 | partial-false  | 8.34M ops/s | 9.65M ops/s | +15.7% | 1.16x      |
-| overlap-n105-r100-018 | partial-false  | 8.29M ops/s | 9.59M ops/s | +15.7% | 1.16x      |
-| overlap-n105-r100-001 | partial-false  | 8.32M ops/s | 9.64M ops/s | +15.8% | 1.16x      |
-| overlap-n105-r100-015 | partial-false  | 8.30M ops/s | 9.63M ops/s | +16.0% | 1.16x      |
-| overlap-n105-r100-012 | partial-false  | 8.22M ops/s | 9.55M ops/s | +16.2% | 1.16x      |
-| overlap-n105-r100-007 | partial-false  | 8.33M ops/s | 9.68M ops/s | +16.2% | 1.16x      |
-| overlap-n105-r100-023 | partial-false  | 8.26M ops/s | 9.60M ops/s | +16.2% | 1.16x      |
-| overlap-n105-r100-004 | partial-false  | 8.26M ops/s | 9.64M ops/s | +16.7% | 1.17x      |
-| overlap-n105-r100-023 | empty-context  | 8.33M ops/s | 9.72M ops/s | +16.7% | 1.17x      |
-| overlap-n105-r100-009 | partial-false  | 8.29M ops/s | 9.69M ops/s | +16.9% | 1.17x      |
-| overlap-n105-r100-016 | partial-false  | 8.33M ops/s | 9.75M ops/s | +17.0% | 1.17x      |
-| overlap-n105-r100-003 | partial-false  | 8.28M ops/s | 9.69M ops/s | +17.0% | 1.17x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| 249-and-or-eqs | complete-false | 9.98M ops/s | 5.63M ops/s | -43.6% | 0.56x |
+| 249-and-or-eqs | complete-true | 3.58M ops/s | 3.36M ops/s | -6.0% | 0.94x |
+| 249-and-or-eqs | partial-true | 3.50M ops/s | 3.36M ops/s | -3.9% | 0.96x |
+| overlap-n105-r100-012 | partial-false | 8.65M ops/s | 9.02M ops/s | +4.3% | 1.04x |
+| overlap-n105-r100-011 | partial-false | 8.65M ops/s | 9.03M ops/s | +4.4% | 1.04x |
+| overlap-n105-r100-013 | partial-false | 8.69M ops/s | 9.10M ops/s | +4.7% | 1.05x |
+| overlap-n105-r100-006 | partial-false | 8.64M ops/s | 9.06M ops/s | +4.8% | 1.05x |
+| overlap-n105-r100-008 | partial-false | 8.57M ops/s | 8.99M ops/s | +4.9% | 1.05x |
+| overlap-n105-r100-014 | partial-false | 8.62M ops/s | 9.06M ops/s | +5.1% | 1.05x |
+| overlap-n105-r100-009 | partial-false | 8.61M ops/s | 9.10M ops/s | +5.7% | 1.06x |
+| overlap-n105-r100-016 | empty-context | 8.87M ops/s | 9.38M ops/s | +5.7% | 1.06x |
+| overlap-n105-r100-007 | partial-false | 8.63M ops/s | 9.14M ops/s | +5.9% | 1.06x |
+| overlap-n105-r100-008 | empty-context | 8.79M ops/s | 9.32M ops/s | +6.1% | 1.06x |
+| overlap-n105-r100-018 | partial-false | 8.68M ops/s | 9.21M ops/s | +6.1% | 1.06x |
+| overlap-n105-r100-005 | partial-false | 8.61M ops/s | 9.14M ops/s | +6.2% | 1.06x |
+| overlap-n105-r100-010 | partial-false | 8.54M ops/s | 9.07M ops/s | +6.2% | 1.06x |
+| overlap-n105-r100-012 | empty-context | 8.83M ops/s | 9.38M ops/s | +6.2% | 1.06x |
+| overlap-n105-r100-001 | partial-false | 8.66M ops/s | 9.21M ops/s | +6.4% | 1.06x |
+| overlap-n105-r100-001 | empty-context | 8.79M ops/s | 9.37M ops/s | +6.6% | 1.07x |
+| overlap-n105-r100-002 | empty-context | 8.80M ops/s | 9.39M ops/s | +6.7% | 1.07x |
 
 ### Regressions
 
-| Group          | Case           | Baseline    | Improved    | Delta  | Multiplier |
-| -------------- | -------------- | ----------- | ----------- | ------ | ---------- |
-| 249-and-or-eqs | complete-false | 9.77M ops/s | 5.78M ops/s | -40.8% | 0.59x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| 249-and-or-eqs | complete-false | 9.98M ops/s | 5.63M ops/s | -43.6% | 0.56x |
+| 249-and-or-eqs | complete-true | 3.58M ops/s | 3.36M ops/s | -6.0% | 0.94x |
+

--- a/benchmark/report-synthetic-evaluate.md
+++ b/benchmark/report-synthetic-evaluate.md
@@ -6,11 +6,11 @@
 
 ## Summary
 
-|               | Count |
-| ------------- | ----- |
-| Faster (>+5%) | 81    |
-| Slower (>-5%) | 11    |
-| Unchanged     | 14    |
+| | Count |
+|---|---|
+| Faster (>+5%) | 84 |
+| Slower (>-5%) | 9 |
+| Unchanged | 13 |
 
 ---
 
@@ -18,66 +18,65 @@
 
 ### Top 20 Most Improved
 
-| Group                   | Case                 | Baseline      | Improved     | Delta     | Multiplier |
-| ----------------------- | -------------------- | ------------- | ------------ | --------- | ---------- |
-| overlap-n1026-r1000-10x | full-execution-true  | 31.68K ops/s  | 15.18M ops/s | +47819.4% | 479.19x    |
-| overlap-n1026-r1000-10x | early-true           | 31.16K ops/s  | 14.61M ops/s | +46794.6% | 468.95x    |
-| overlap-n1026-r1000-10x | complete-true        | 32.01K ops/s  | 14.99M ops/s | +46730.1% | 468.30x    |
-| overlap-n1026-r1000-10x | partial-true         | 44.52K ops/s  | 15.35M ops/s | +34375.0% | 344.75x    |
-| overlap-n526-r500-5x    | complete-true        | 64.66K ops/s  | 14.88M ops/s | +22910.8% | 230.11x    |
-| overlap-n526-r500-5x    | full-execution-true  | 66.79K ops/s  | 15.07M ops/s | +22457.9% | 225.58x    |
-| overlap-n526-r500-5x    | early-true           | 66.00K ops/s  | 14.77M ops/s | +22278.2% | 223.78x    |
-| overlap-n526-r500-5x    | partial-true         | 92.57K ops/s  | 15.48M ops/s | +16624.8% | 167.25x    |
-| in-n1224-r1-10x         | late-true            | 263.62K ops/s | 20.10M ops/s | +7523.9%  | 76.24x     |
-| in-n1224-r1-10x         | empty-context        | 328.07K ops/s | 23.13M ops/s | +6950.6%  | 70.51x     |
-| in-n1224-r1-10x         | partial-false        | 334.04K ops/s | 23.13M ops/s | +6824.9%  | 69.25x     |
-| in-n1224-r1-10x         | full-execution-false | 273.36K ops/s | 18.72M ops/s | +6748.6%  | 68.49x     |
-| in-n1224-r1-10x         | complete-false       | 274.14K ops/s | 18.30M ops/s | +6577.2%  | 66.77x     |
-| in-n1224-r1-10x         | partial-true         | 332.91K ops/s | 20.32M ops/s | +6005.2%  | 61.05x     |
-| in-n1224-r1-10x         | early-true           | 334.63K ops/s | 19.92M ops/s | +5853.0%  | 59.53x     |
-| in-n1224-r1-10x         | full-execution-true  | 335.81K ops/s | 19.43M ops/s | +5684.8%  | 57.85x     |
-| in-n1224-r1-10x         | complete-true        | 338.68K ops/s | 19.25M ops/s | +5582.8%  | 56.83x     |
-| in-n614-r1-5x           | late-true            | 506.94K ops/s | 21.50M ops/s | +4140.4%  | 42.40x     |
-| in-n614-r1-5x           | empty-context        | 662.33K ops/s | 24.24M ops/s | +3559.2%  | 36.59x     |
-| in-n614-r1-5x           | complete-false       | 545.56K ops/s | 19.88M ops/s | +3544.8%  | 36.45x     |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| overlap-n1026-r1000-10x | full-execution-true | 32.00K ops/s | 14.30M ops/s | +44587.8% | 446.88x |
+| overlap-n1026-r1000-10x | complete-true | 32.72K ops/s | 14.50M ops/s | +44228.3% | 443.28x |
+| overlap-n1026-r1000-10x | early-true | 31.73K ops/s | 13.97M ops/s | +43923.3% | 440.23x |
+| overlap-n1026-r1000-10x | partial-true | 43.29K ops/s | 15.51M ops/s | +35717.1% | 358.17x |
+| overlap-n526-r500-5x | complete-true | 67.90K ops/s | 14.44M ops/s | +21172.6% | 212.73x |
+| overlap-n526-r500-5x | early-true | 68.32K ops/s | 14.40M ops/s | +20975.6% | 210.76x |
+| overlap-n526-r500-5x | full-execution-true | 67.69K ops/s | 13.59M ops/s | +19982.0% | 200.82x |
+| overlap-n526-r500-5x | partial-true | 91.98K ops/s | 14.73M ops/s | +15915.4% | 160.15x |
+| in-n1224-r1-10x | late-true | 259.71K ops/s | 20.63M ops/s | +7843.7% | 79.44x |
+| in-n1224-r1-10x | empty-context | 326.58K ops/s | 24.22M ops/s | +7316.9% | 74.17x |
+| in-n1224-r1-10x | full-execution-false | 272.30K ops/s | 19.16M ops/s | +6937.6% | 70.38x |
+| in-n1224-r1-10x | complete-false | 271.71K ops/s | 19.05M ops/s | +6911.8% | 70.12x |
+| in-n1224-r1-10x | partial-false | 333.98K ops/s | 23.06M ops/s | +6804.6% | 69.05x |
+| in-n1224-r1-10x | early-true | 333.83K ops/s | 18.88M ops/s | +5556.5% | 56.56x |
+| in-n1224-r1-10x | full-execution-true | 336.29K ops/s | 18.84M ops/s | +5501.9% | 56.02x |
+| in-n1224-r1-10x | partial-true | 334.77K ops/s | 17.57M ops/s | +5148.1% | 52.48x |
+| in-n1224-r1-10x | complete-true | 335.47K ops/s | 17.48M ops/s | +5109.8% | 52.10x |
+| in-n614-r1-5x | late-true | 496.47K ops/s | 20.75M ops/s | +4079.7% | 41.80x |
+| in-n614-r1-5x | empty-context | 653.34K ops/s | 23.53M ops/s | +3501.8% | 36.02x |
+| overlap-n447-r50-10x | early-true | 492.86K ops/s | 17.59M ops/s | +3468.6% | 35.69x |
 
 ### Top 20 Least Improved
 
-| Group                       | Case                 | Baseline     | Improved     | Delta  | Multiplier |
-| --------------------------- | -------------------- | ------------ | ------------ | ------ | ---------- |
-| expression-medium-or        | late-true            | 10.98M ops/s | 8.60M ops/s  | -21.7% | 0.78x      |
-| expression-medium-or        | empty-context        | 10.71M ops/s | 8.47M ops/s  | -20.9% | 0.79x      |
-| expression-medium-or        | full-execution-true  | 10.73M ops/s | 8.59M ops/s  | -19.9% | 0.80x      |
-| expression-medium-or        | early-true           | 19.64M ops/s | 15.75M ops/s | -19.8% | 0.80x      |
-| expression-medium-or        | partial-true         | 19.40M ops/s | 15.70M ops/s | -19.1% | 0.81x      |
-| expression-medium-or        | partial-false        | 10.13M ops/s | 8.24M ops/s  | -18.7% | 0.81x      |
-| expression-medium-or        | complete-false       | 10.56M ops/s | 8.77M ops/s  | -17.0% | 0.83x      |
-| expression-medium-or        | complete-true        | 18.51M ops/s | 15.45M ops/s | -16.5% | 0.83x      |
-| expression-medium-or        | full-execution-false | 10.47M ops/s | 8.77M ops/s  | -16.3% | 0.84x      |
-| expression-deep-nested      | partial-false        | 15.12M ops/s | 14.17M ops/s | -6.3%  | 0.94x      |
-| expression-deep-nested      | empty-context        | 15.25M ops/s | 14.34M ops/s | -6.0%  | 0.94x      |
-| expression-deep-nested      | late-true            | 4.34M ops/s  | 4.22M ops/s  | -2.8%  | 0.97x      |
-| expression-deep-nested      | full-execution-false | 4.32M ops/s  | 4.24M ops/s  | -2.0%  | 0.98x      |
-| expression-reference-nested | partial-false        | 14.58M ops/s | 14.31M ops/s | -1.9%  | 0.98x      |
-| expression-reference-nested | empty-context        | 14.65M ops/s | 14.47M ops/s | -1.2%  | 0.99x      |
-| expression-reference-nested | complete-false       | 13.47M ops/s | 13.42M ops/s | -0.4%  | 1.00x      |
-| expression-deep-nested      | complete-false       | 13.39M ops/s | 13.43M ops/s | +0.3%  | 1.00x      |
-| expression-complex-nested   | partial-false        | 15.07M ops/s | 15.32M ops/s | +1.6%  | 1.02x      |
-| expression-medium-and       | empty-context        | 15.37M ops/s | 15.72M ops/s | +2.3%  | 1.02x      |
-| expression-date-arithmetic  | empty-context        | 15.12M ops/s | 15.54M ops/s | +2.8%  | 1.03x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| expression-medium-or | complete-true | 20.23M ops/s | 16.21M ops/s | -19.9% | 0.80x |
+| expression-medium-or | partial-true | 20.17M ops/s | 16.37M ops/s | -18.8% | 0.81x |
+| expression-medium-or | early-true | 20.05M ops/s | 16.31M ops/s | -18.7% | 0.81x |
+| expression-medium-or | empty-context | 10.76M ops/s | 8.91M ops/s | -17.3% | 0.83x |
+| expression-medium-or | full-execution-true | 10.59M ops/s | 8.87M ops/s | -16.2% | 0.84x |
+| expression-medium-or | late-true | 10.62M ops/s | 8.90M ops/s | -16.2% | 0.84x |
+| expression-medium-or | partial-false | 9.96M ops/s | 8.39M ops/s | -15.8% | 0.84x |
+| expression-medium-or | complete-false | 10.46M ops/s | 8.94M ops/s | -14.5% | 0.85x |
+| expression-medium-or | full-execution-false | 10.23M ops/s | 8.79M ops/s | -14.1% | 0.86x |
+| expression-reference-nested | empty-context | 15.23M ops/s | 15.05M ops/s | -1.2% | 0.99x |
+| expression-reference-nested | partial-false | 14.79M ops/s | 14.65M ops/s | -0.9% | 0.99x |
+| expression-complex-nested | empty-context | 15.72M ops/s | 15.58M ops/s | -0.9% | 0.99x |
+| expression-deep-nested | full-execution-false | 4.22M ops/s | 4.21M ops/s | -0.3% | 1.00x |
+| expression-deep-nested | partial-false | 14.57M ops/s | 14.59M ops/s | +0.1% | 1.00x |
+| expression-complex-nested | partial-false | 15.33M ops/s | 15.42M ops/s | +0.5% | 1.01x |
+| expression-medium-and | empty-context | 15.59M ops/s | 15.81M ops/s | +1.4% | 1.01x |
+| expression-reference-nested | complete-false | 13.72M ops/s | 13.98M ops/s | +1.9% | 1.02x |
+| expression-deep-nested | empty-context | 14.69M ops/s | 14.98M ops/s | +2.0% | 1.02x |
+| expression-deep-nested | late-true | 4.14M ops/s | 4.22M ops/s | +2.0% | 1.02x |
+| expression-medium-and | complete-false | 15.28M ops/s | 15.74M ops/s | +3.0% | 1.03x |
 
 ### Regressions
 
-| Group                  | Case                 | Baseline     | Improved     | Delta  | Multiplier |
-| ---------------------- | -------------------- | ------------ | ------------ | ------ | ---------- |
-| expression-medium-or   | late-true            | 10.98M ops/s | 8.60M ops/s  | -21.7% | 0.78x      |
-| expression-medium-or   | empty-context        | 10.71M ops/s | 8.47M ops/s  | -20.9% | 0.79x      |
-| expression-medium-or   | full-execution-true  | 10.73M ops/s | 8.59M ops/s  | -19.9% | 0.80x      |
-| expression-medium-or   | early-true           | 19.64M ops/s | 15.75M ops/s | -19.8% | 0.80x      |
-| expression-medium-or   | partial-true         | 19.40M ops/s | 15.70M ops/s | -19.1% | 0.81x      |
-| expression-medium-or   | partial-false        | 10.13M ops/s | 8.24M ops/s  | -18.7% | 0.81x      |
-| expression-medium-or   | complete-false       | 10.56M ops/s | 8.77M ops/s  | -17.0% | 0.83x      |
-| expression-medium-or   | complete-true        | 18.51M ops/s | 15.45M ops/s | -16.5% | 0.83x      |
-| expression-medium-or   | full-execution-false | 10.47M ops/s | 8.77M ops/s  | -16.3% | 0.84x      |
-| expression-deep-nested | partial-false        | 15.12M ops/s | 14.17M ops/s | -6.3%  | 0.94x      |
-| expression-deep-nested | empty-context        | 15.25M ops/s | 14.34M ops/s | -6.0%  | 0.94x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| expression-medium-or | complete-true | 20.23M ops/s | 16.21M ops/s | -19.9% | 0.80x |
+| expression-medium-or | partial-true | 20.17M ops/s | 16.37M ops/s | -18.8% | 0.81x |
+| expression-medium-or | early-true | 20.05M ops/s | 16.31M ops/s | -18.7% | 0.81x |
+| expression-medium-or | empty-context | 10.76M ops/s | 8.91M ops/s | -17.3% | 0.83x |
+| expression-medium-or | full-execution-true | 10.59M ops/s | 8.87M ops/s | -16.2% | 0.84x |
+| expression-medium-or | late-true | 10.62M ops/s | 8.90M ops/s | -16.2% | 0.84x |
+| expression-medium-or | partial-false | 9.96M ops/s | 8.39M ops/s | -15.8% | 0.84x |
+| expression-medium-or | complete-false | 10.46M ops/s | 8.94M ops/s | -14.5% | 0.85x |
+| expression-medium-or | full-execution-false | 10.23M ops/s | 8.79M ops/s | -14.1% | 0.86x |
+

--- a/benchmark/report-synthetic-simplify.md
+++ b/benchmark/report-synthetic-simplify.md
@@ -6,11 +6,11 @@
 
 ## Summary
 
-|               | Count |
-| ------------- | ----- |
-| Faster (>+5%) | 54    |
-| Slower (>-5%) | 25    |
-| Unchanged     | 8     |
+| | Count |
+|---|---|
+| Faster (>+5%) | 55 |
+| Slower (>-5%) | 26 |
+| Unchanged | 6 |
 
 ---
 
@@ -18,80 +18,82 @@
 
 ### Top 20 Most Improved
 
-| Group                | Case                 | Baseline      | Improved    | Delta    | Multiplier |
-| -------------------- | -------------------- | ------------- | ----------- | -------- | ---------- |
-| in-n1224-r1-10x      | complete-false       | 97.60K ops/s  | 9.72M ops/s | +9857.5% | 99.58x     |
-| in-n1224-r1-10x      | full-execution-false | 97.87K ops/s  | 9.70M ops/s | +9813.8% | 99.14x     |
-| in-n1224-r1-10x      | partial-true         | 105.01K ops/s | 9.26M ops/s | +8721.4% | 88.21x     |
-| in-n1224-r1-10x      | complete-true        | 105.22K ops/s | 9.17M ops/s | +8614.1% | 87.14x     |
-| in-n1224-r1-10x      | full-execution-true  | 106.49K ops/s | 9.15M ops/s | +8493.0% | 85.93x     |
-| in-n1224-r1-10x      | empty-context        | 104.98K ops/s | 8.87M ops/s | +8345.6% | 84.46x     |
-| in-n1224-r1-10x      | partial-false        | 106.13K ops/s | 8.82M ops/s | +8209.9% | 83.10x     |
-| in-n614-r1-5x        | full-execution-false | 186.76K ops/s | 9.53M ops/s | +5005.2% | 51.05x     |
-| in-n614-r1-5x        | complete-false       | 186.86K ops/s | 9.39M ops/s | +4926.1% | 50.26x     |
-| in-n614-r1-5x        | complete-true        | 201.70K ops/s | 9.07M ops/s | +4396.6% | 44.97x     |
-| in-n614-r1-5x        | partial-true         | 202.20K ops/s | 9.06M ops/s | +4379.3% | 44.79x     |
-| in-n614-r1-5x        | full-execution-true  | 201.84K ops/s | 9.03M ops/s | +4375.5% | 44.76x     |
-| in-n614-r1-5x        | empty-context        | 199.10K ops/s | 8.85M ops/s | +4346.3% | 44.46x     |
-| in-n614-r1-5x        | partial-false        | 202.30K ops/s | 8.85M ops/s | +4273.3% | 43.73x     |
-| overlap-n447-r50-10x | partial-false        | 313.35K ops/s | 9.73M ops/s | +3005.1% | 31.05x     |
-| overlap-n447-r50-10x | empty-context        | 320.44K ops/s | 9.41M ops/s | +2836.4% | 29.36x     |
-| overlap-n447-r50-10x | complete-true        | 311.43K ops/s | 8.72M ops/s | +2698.7% | 27.99x     |
-| overlap-n447-r50-10x | full-execution-true  | 311.79K ops/s | 8.56M ops/s | +2646.0% | 27.46x     |
-| overlap-n447-r50-10x | partial-true         | 313.92K ops/s | 8.51M ops/s | +2610.3% | 27.10x     |
-| overlap-n447-r50-10x | full-execution-false | 63.74K ops/s  | 1.17M ops/s | +1736.7% | 18.37x     |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| in-n1224-r1-10x | complete-false | 101.55K ops/s | 9.64M ops/s | +9397.6% | 94.98x |
+| in-n1224-r1-10x | full-execution-false | 101.04K ops/s | 9.53M ops/s | +9328.2% | 94.28x |
+| in-n1224-r1-10x | partial-true | 108.98K ops/s | 9.52M ops/s | +8637.2% | 87.37x |
+| in-n1224-r1-10x | complete-true | 110.08K ops/s | 9.56M ops/s | +8583.9% | 86.84x |
+| in-n1224-r1-10x | full-execution-true | 108.96K ops/s | 9.45M ops/s | +8574.8% | 86.75x |
+| in-n1224-r1-10x | partial-false | 107.96K ops/s | 8.57M ops/s | +7842.3% | 79.42x |
+| in-n1224-r1-10x | empty-context | 109.65K ops/s | 8.54M ops/s | +7689.8% | 77.90x |
+| in-n614-r1-5x | complete-false | 189.90K ops/s | 9.69M ops/s | +5003.7% | 51.04x |
+| in-n614-r1-5x | full-execution-false | 193.13K ops/s | 9.63M ops/s | +4886.2% | 49.86x |
+| in-n614-r1-5x | complete-true | 204.51K ops/s | 9.68M ops/s | +4631.8% | 47.32x |
+| in-n614-r1-5x | partial-true | 203.51K ops/s | 9.63M ops/s | +4629.4% | 47.29x |
+| in-n614-r1-5x | full-execution-true | 205.14K ops/s | 9.61M ops/s | +4583.4% | 46.83x |
+| in-n614-r1-5x | partial-false | 205.75K ops/s | 8.51M ops/s | +4034.2% | 41.34x |
+| in-n614-r1-5x | empty-context | 209.76K ops/s | 8.57M ops/s | +3985.8% | 40.86x |
+| overlap-n447-r50-10x | empty-context | 327.05K ops/s | 9.25M ops/s | +2726.9% | 28.27x |
+| overlap-n447-r50-10x | partial-false | 326.75K ops/s | 9.12M ops/s | +2691.3% | 27.91x |
+| overlap-n447-r50-10x | full-execution-true | 323.45K ops/s | 8.56M ops/s | +2547.8% | 26.48x |
+| overlap-n447-r50-10x | complete-true | 328.36K ops/s | 8.65M ops/s | +2533.3% | 26.33x |
+| overlap-n447-r50-10x | partial-true | 319.54K ops/s | 8.08M ops/s | +2429.5% | 25.29x |
+| overlap-n447-r50-10x | complete-false | 65.71K ops/s | 1.12M ops/s | +1598.4% | 16.98x |
 
 ### Top 20 Least Improved
 
-| Group                       | Case                 | Baseline     | Improved    | Delta  | Multiplier |
-| --------------------------- | -------------------- | ------------ | ----------- | ------ | ---------- |
-| expression-medium-or        | complete-true        | 10.27M ops/s | 7.05M ops/s | -31.3% | 0.69x      |
-| expression-medium-or        | partial-true         | 9.99M ops/s  | 7.02M ops/s | -29.8% | 0.70x      |
-| expression-medium-and       | complete-false       | 10.05M ops/s | 7.29M ops/s | -27.5% | 0.72x      |
-| expression-date-arithmetic  | complete-false       | 9.92M ops/s  | 7.24M ops/s | -27.0% | 0.73x      |
-| expression-complex-nested   | complete-false       | 9.71M ops/s  | 7.22M ops/s | -25.6% | 0.74x      |
-| expression-reference-nested | complete-false       | 8.82M ops/s  | 6.65M ops/s | -24.7% | 0.75x      |
-| expression-deep-nested      | complete-false       | 8.89M ops/s  | 6.71M ops/s | -24.5% | 0.76x      |
-| expression-simple-eq        | complete-true        | 12.70M ops/s | 9.64M ops/s | -24.1% | 0.76x      |
-| expression-simple-eq        | full-execution-true  | 12.80M ops/s | 9.78M ops/s | -23.6% | 0.76x      |
-| expression-simple-eq        | partial-true         | 12.84M ops/s | 9.82M ops/s | -23.5% | 0.76x      |
-| expression-simple-eq        | complete-false       | 12.57M ops/s | 9.77M ops/s | -22.3% | 0.78x      |
-| expression-simple-eq        | full-execution-false | 12.50M ops/s | 9.73M ops/s | -22.2% | 0.78x      |
-| expression-simple-ne        | complete-true        | 11.97M ops/s | 9.57M ops/s | -20.0% | 0.80x      |
-| expression-reference-nested | full-execution-false | 5.02M ops/s  | 4.14M ops/s | -17.6% | 0.82x      |
-| expression-simple-eq        | partial-false        | 10.16M ops/s | 8.40M ops/s | -17.3% | 0.83x      |
-| expression-simple-eq        | empty-context        | 9.98M ops/s  | 8.42M ops/s | -15.6% | 0.84x      |
-| expression-deep-nested      | full-execution-false | 2.55M ops/s  | 2.18M ops/s | -14.4% | 0.86x      |
-| expression-medium-or        | complete-false       | 4.41M ops/s  | 3.94M ops/s | -10.7% | 0.89x      |
-| expression-medium-or        | full-execution-false | 4.40M ops/s  | 3.94M ops/s | -10.5% | 0.89x      |
-| expression-medium-or        | full-execution-true  | 4.37M ops/s  | 3.92M ops/s | -10.2% | 0.90x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| expression-medium-or | complete-true | 10.24M ops/s | 7.21M ops/s | -29.6% | 0.70x |
+| expression-medium-or | partial-true | 10.15M ops/s | 7.14M ops/s | -29.6% | 0.70x |
+| expression-date-arithmetic | complete-false | 9.91M ops/s | 7.38M ops/s | -25.6% | 0.74x |
+| expression-medium-and | complete-false | 9.84M ops/s | 7.38M ops/s | -25.1% | 0.75x |
+| expression-simple-eq | partial-true | 12.86M ops/s | 9.72M ops/s | -24.5% | 0.76x |
+| expression-simple-eq | complete-true | 12.97M ops/s | 9.82M ops/s | -24.3% | 0.76x |
+| expression-reference-nested | complete-false | 8.90M ops/s | 6.79M ops/s | -23.7% | 0.76x |
+| expression-simple-ne | complete-true | 12.69M ops/s | 9.68M ops/s | -23.7% | 0.76x |
+| expression-simple-eq | full-execution-false | 12.55M ops/s | 9.64M ops/s | -23.2% | 0.77x |
+| expression-simple-eq | complete-false | 12.70M ops/s | 9.76M ops/s | -23.2% | 0.77x |
+| expression-deep-nested | complete-false | 8.88M ops/s | 6.85M ops/s | -22.9% | 0.77x |
+| expression-simple-eq | full-execution-true | 12.59M ops/s | 9.75M ops/s | -22.5% | 0.77x |
+| expression-complex-nested | complete-false | 9.38M ops/s | 7.35M ops/s | -21.7% | 0.78x |
+| expression-simple-ne | empty-context | 9.75M ops/s | 7.97M ops/s | -18.2% | 0.82x |
+| expression-reference-nested | full-execution-false | 4.98M ops/s | 4.09M ops/s | -17.9% | 0.82x |
+| expression-simple-eq | partial-false | 9.76M ops/s | 8.03M ops/s | -17.7% | 0.82x |
+| expression-simple-eq | empty-context | 9.78M ops/s | 8.08M ops/s | -17.4% | 0.83x |
+| expression-simple-ne | full-execution-true | 9.98M ops/s | 8.28M ops/s | -17.0% | 0.83x |
+| expression-simple-ne | partial-true | 9.58M ops/s | 8.02M ops/s | -16.3% | 0.84x |
+| expression-medium-or | full-execution-true | 4.46M ops/s | 3.98M ops/s | -10.7% | 0.89x |
 
 ### Regressions
 
-| Group                       | Case                 | Baseline     | Improved    | Delta  | Multiplier |
-| --------------------------- | -------------------- | ------------ | ----------- | ------ | ---------- |
-| expression-medium-or        | complete-true        | 10.27M ops/s | 7.05M ops/s | -31.3% | 0.69x      |
-| expression-medium-or        | partial-true         | 9.99M ops/s  | 7.02M ops/s | -29.8% | 0.70x      |
-| expression-medium-and       | complete-false       | 10.05M ops/s | 7.29M ops/s | -27.5% | 0.72x      |
-| expression-date-arithmetic  | complete-false       | 9.92M ops/s  | 7.24M ops/s | -27.0% | 0.73x      |
-| expression-complex-nested   | complete-false       | 9.71M ops/s  | 7.22M ops/s | -25.6% | 0.74x      |
-| expression-reference-nested | complete-false       | 8.82M ops/s  | 6.65M ops/s | -24.7% | 0.75x      |
-| expression-deep-nested      | complete-false       | 8.89M ops/s  | 6.71M ops/s | -24.5% | 0.76x      |
-| expression-simple-eq        | complete-true        | 12.70M ops/s | 9.64M ops/s | -24.1% | 0.76x      |
-| expression-simple-eq        | full-execution-true  | 12.80M ops/s | 9.78M ops/s | -23.6% | 0.76x      |
-| expression-simple-eq        | partial-true         | 12.84M ops/s | 9.82M ops/s | -23.5% | 0.76x      |
-| expression-simple-eq        | complete-false       | 12.57M ops/s | 9.77M ops/s | -22.3% | 0.78x      |
-| expression-simple-eq        | full-execution-false | 12.50M ops/s | 9.73M ops/s | -22.2% | 0.78x      |
-| expression-simple-ne        | complete-true        | 11.97M ops/s | 9.57M ops/s | -20.0% | 0.80x      |
-| expression-reference-nested | full-execution-false | 5.02M ops/s  | 4.14M ops/s | -17.6% | 0.82x      |
-| expression-simple-eq        | partial-false        | 10.16M ops/s | 8.40M ops/s | -17.3% | 0.83x      |
-| expression-simple-eq        | empty-context        | 9.98M ops/s  | 8.42M ops/s | -15.6% | 0.84x      |
-| expression-deep-nested      | full-execution-false | 2.55M ops/s  | 2.18M ops/s | -14.4% | 0.86x      |
-| expression-medium-or        | complete-false       | 4.41M ops/s  | 3.94M ops/s | -10.7% | 0.89x      |
-| expression-medium-or        | full-execution-false | 4.40M ops/s  | 3.94M ops/s | -10.5% | 0.89x      |
-| expression-medium-or        | full-execution-true  | 4.37M ops/s  | 3.92M ops/s | -10.2% | 0.90x      |
-| expression-simple-ne        | full-execution-true  | 9.32M ops/s  | 8.51M ops/s | -8.7%  | 0.91x      |
-| expression-simple-ne        | empty-context        | 9.16M ops/s  | 8.38M ops/s | -8.5%  | 0.91x      |
-| expression-medium-and       | full-execution-false | 3.37M ops/s  | 3.08M ops/s | -8.5%  | 0.92x      |
-| expression-simple-ne        | partial-true         | 9.13M ops/s  | 8.42M ops/s | -7.7%  | 0.92x      |
-| expression-arithmetic       | partial-false        | 2.46M ops/s  | 2.33M ops/s | -5.2%  | 0.95x      |
+| Group | Case | Baseline | Improved | Delta | Multiplier |
+|-------|------|----------|----------|-------|------------|
+| expression-medium-or | complete-true | 10.24M ops/s | 7.21M ops/s | -29.6% | 0.70x |
+| expression-medium-or | partial-true | 10.15M ops/s | 7.14M ops/s | -29.6% | 0.70x |
+| expression-date-arithmetic | complete-false | 9.91M ops/s | 7.38M ops/s | -25.6% | 0.74x |
+| expression-medium-and | complete-false | 9.84M ops/s | 7.38M ops/s | -25.1% | 0.75x |
+| expression-simple-eq | partial-true | 12.86M ops/s | 9.72M ops/s | -24.5% | 0.76x |
+| expression-simple-eq | complete-true | 12.97M ops/s | 9.82M ops/s | -24.3% | 0.76x |
+| expression-reference-nested | complete-false | 8.90M ops/s | 6.79M ops/s | -23.7% | 0.76x |
+| expression-simple-ne | complete-true | 12.69M ops/s | 9.68M ops/s | -23.7% | 0.76x |
+| expression-simple-eq | full-execution-false | 12.55M ops/s | 9.64M ops/s | -23.2% | 0.77x |
+| expression-simple-eq | complete-false | 12.70M ops/s | 9.76M ops/s | -23.2% | 0.77x |
+| expression-deep-nested | complete-false | 8.88M ops/s | 6.85M ops/s | -22.9% | 0.77x |
+| expression-simple-eq | full-execution-true | 12.59M ops/s | 9.75M ops/s | -22.5% | 0.77x |
+| expression-complex-nested | complete-false | 9.38M ops/s | 7.35M ops/s | -21.7% | 0.78x |
+| expression-simple-ne | empty-context | 9.75M ops/s | 7.97M ops/s | -18.2% | 0.82x |
+| expression-reference-nested | full-execution-false | 4.98M ops/s | 4.09M ops/s | -17.9% | 0.82x |
+| expression-simple-eq | partial-false | 9.76M ops/s | 8.03M ops/s | -17.7% | 0.82x |
+| expression-simple-eq | empty-context | 9.78M ops/s | 8.08M ops/s | -17.4% | 0.83x |
+| expression-simple-ne | full-execution-true | 9.98M ops/s | 8.28M ops/s | -17.0% | 0.83x |
+| expression-simple-ne | partial-true | 9.58M ops/s | 8.02M ops/s | -16.3% | 0.84x |
+| expression-medium-or | full-execution-true | 4.46M ops/s | 3.98M ops/s | -10.7% | 0.89x |
+| expression-medium-or | full-execution-false | 4.45M ops/s | 3.99M ops/s | -10.4% | 0.90x |
+| expression-medium-or | complete-false | 4.43M ops/s | 3.99M ops/s | -9.9% | 0.90x |
+| expression-deep-nested | full-execution-false | 2.40M ops/s | 2.17M ops/s | -9.3% | 0.91x |
+| expression-medium-and | full-execution-false | 3.43M ops/s | 3.14M ops/s | -8.5% | 0.92x |
+| expression-arithmetic | full-execution-false | 2.47M ops/s | 2.27M ops/s | -7.9% | 0.92x |
+| expression-arithmetic | empty-context | 2.43M ops/s | 2.26M ops/s | -7.2% | 0.93x |
+

--- a/conditions/simplify-conditions/249-and-or-eqs.json
+++ b/conditions/simplify-conditions/249-and-or-eqs.json
@@ -1,0 +1,38 @@
+{
+  "description": "AND OR EQs → remain unchanged",
+  "expression": [
+    "AND",
+    ["AND", ["==", "$LossHasAny", "yes"], ["==", "$Loss1Type", "property"]],
+    [
+      "OR",
+      [
+        "AND",
+        ["==", "$Loss1Type", "property"],
+        ["==", "$Loss1ClaimStatus", "closed"]
+      ],
+      [
+        "AND",
+        ["==", "$Loss1Type", "property"],
+        ["==", "$Loss1ClaimStatus", "declined"]
+      ]
+    ]
+  ],
+  "context": {},
+  "expected": [
+    "AND",
+    ["AND", ["==", "$LossHasAny", "yes"], ["==", "$Loss1Type", "property"]],
+    [
+      "OR",
+      [
+        "AND",
+        ["==", "$Loss1Type", "property"],
+        ["==", "$Loss1ClaimStatus", "closed"]
+      ],
+      [
+        "AND",
+        ["==", "$Loss1Type", "property"],
+        ["==", "$Loss1ClaimStatus", "declined"]
+      ]
+    ]
+  ]
+}

--- a/conditions/simplify-conditions/250-or-and-in.json
+++ b/conditions/simplify-conditions/250-or-and-in.json
@@ -1,0 +1,30 @@
+{
+  "description": "OR AND INs → remain unchanged",
+  "expression": [
+    "OR",
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "closed"]
+    ],
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "declined"]
+    ]
+  ],
+  "context": {},
+  "expected": [
+    "OR",
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "closed"]
+    ],
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "declined"]
+    ]
+  ]
+}

--- a/conditions/simplify-conditions/251-or-and-in-mixed-eq-in.json
+++ b/conditions/simplify-conditions/251-or-and-in-mixed-eq-in.json
@@ -1,0 +1,30 @@
+{
+  "description": "OR AND INs with mixed operators fallback to IN",
+  "expression": [
+    "OR",
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "closed"]
+    ],
+    [
+      "AND",
+      ["IN", "$Loss1Type", ["property", "home"]],
+      ["==", "$Loss1ClaimStatus", "declined"]
+    ]
+  ],
+  "context": {},
+  "expected": [
+    "OR",
+    [
+      "AND",
+      ["==", "$Loss1Type", "property"],
+      ["==", "$Loss1ClaimStatus", "closed"]
+    ],
+    [
+      "AND",
+      ["IN", "$Loss1Type", ["property", "home"]],
+      ["==", "$Loss1ClaimStatus", "declined"]
+    ]
+  ]
+}

--- a/conditions/simplify-conditions/252-deep-composite.json
+++ b/conditions/simplify-conditions/252-deep-composite.json
@@ -1,0 +1,38 @@
+{
+  "description": "deep OR/AND/OR composite with context -> simplify preserves structure (bytecode must match OOP)",
+  "expression": [
+    "OR",
+    [
+      "AND",
+      [
+        "OR",
+        ["==", "$A", 18],
+        ["AND", ["==", "$E", 5], ["==", "$F", "yes"]]
+      ],
+      ["==", "$D", 1],
+      ["==", "$X", 2],
+      ["==", "$Y", 3]
+    ],
+    ["==", "$A", "yes"],
+    [
+      "OR",
+      ["==", "$C", "yes"],
+      ["AND", ["==", "$B", "no"], ["IN", "$A", [13, 14]]]
+    ]
+  ],
+  "context": {
+    "A": 15,
+    "E": 5
+  },
+  "expected": [
+    "OR",
+    [
+      "AND",
+      ["==", "$F", "yes"],
+      ["==", "$D", 1],
+      ["==", "$X", 2],
+      ["==", "$Y", 3]
+    ],
+    ["==", "$C", "yes"]
+  ]
+}

--- a/src/__test__/unit/detectOrAndIn2Pattern.test.ts
+++ b/src/__test__/unit/detectOrAndIn2Pattern.test.ts
@@ -39,6 +39,7 @@ describe('detectOrAndIn2Pattern', () => {
       constIndex: new Map(),
       overlapRefsEntries: [],
       directionEntries: [],
+      simplify: false,
     }
   })
 

--- a/src/__test__/unit/simplify-deep-nesting.test.ts
+++ b/src/__test__/unit/simplify-deep-nesting.test.ts
@@ -1,0 +1,130 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+
+import type { ContextValue } from '../../common/evaluable.js'
+import Engine, {
+  type Context,
+  type ExpressionInput,
+  type Input,
+} from '../../index.js'
+
+/**
+ * Generality of the bytecode `simplify` for OR/AND nesting depth.
+ *
+ * The regression fixed by this change was the simplify merge optimization
+ * collapsing nested OR/AND structure. That optimization was skipped for
+ * simplify, so reconstruction falls back to the general short-circuit path,
+ * which handles arbitrary nesting depth. The old merge only reconstructed the
+ * specific 2-level `OR(AND(ref1,ref2), …)` shape.
+ *
+ * This suite locks in that the fix is *generic* (not limited to 2 or 3 levels):
+ *   1. bytecode simplify reproduces the OOP simplify verbatim for deep spirals
+ *      and wide merges (structural, instant);
+ *   2. the simplified form never changes the evaluated truth table for several
+ *      depths (behavioral, bounded completions — kept shallow to stay fast).
+ */
+
+const leaf = (ref: string, val: Input): ExpressionInput =>
+  ['==', '$' + ref, val] as ExpressionInput
+
+// Alternating OR/AND "spiral": wrap the previous structure, then add leaves.
+// depth == nesting depth of the OR/AND alternation.
+const buildSpiral = (depth: number): ExpressionInput => {
+  let cur: ExpressionInput = leaf('r0', 0)
+  for (let d = 1; d <= depth; d++) {
+    const op = d % 2 === 1 ? 'OR' : 'AND'
+    cur = [
+      op,
+      cur,
+      leaf('a' + d, d),
+      leaf('b' + d, d * 2 + 1),
+    ] as ExpressionInput
+  }
+  return cur
+}
+
+const buildWideMerge = (branches: number): ExpressionInput => {
+  const bs: ExpressionInput[] = []
+  for (let k = 0; k < branches; k++) {
+    bs.push(['AND', ['==', '$shared', k], leaf('w' + k, k)] as ExpressionInput)
+  }
+  return ['OR', ...bs] as ExpressionInput
+}
+
+const oop = new Engine({ evaluator: 'oop' })
+const bytecode = new Engine({ evaluator: 'bytecode' })
+
+// (1) Structural: bytecode must reproduce the OOP simplify verbatim at every
+// tested depth / branch count. Instant.
+for (let depth = 2; depth <= 10; depth++) {
+  test(`simplify reproduces OOP verbatim for deep spiral depth ${depth}`, () => {
+    const exp = buildSpiral(depth)
+    const ctx: Context = { r0: 5 }
+    assert.deepStrictEqual(bytecode.simplify(exp, ctx), oop.simplify(exp, ctx))
+  })
+}
+
+for (let branches = 2; branches <= 8; branches++) {
+  test(`simplify reproduces OOP verbatim for wide merge (${branches} branches)`, () => {
+    const exp = buildWideMerge(branches)
+    const ctx: Context = { r0: 5 }
+    assert.deepStrictEqual(bytecode.simplify(exp, ctx), oop.simplify(exp, ctx))
+  })
+}
+
+// (2) Behavioral: the simplified form must never change the evaluated truth
+// table. Bounded completions, kept shallow (depth <= 3) so the suite stays fast.
+const DOMAIN: ContextValue[] = [undefined, null, 1, 2, 3, 100, -5]
+
+function assertEvalEquivalent(exp: ExpressionInput, maxDepth: number): void {
+  const ctx = { r0: 5 }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const oopSimp = oop.simplify(exp, ctx) as ExpressionInput
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const bcSimp = bytecode.simplify(exp, ctx) as ExpressionInput
+
+  const refs = new Set<string>()
+  const walk = (e: unknown): void => {
+    if (Array.isArray(e)) {
+      for (const x of e) {
+        walk(x)
+      }
+    } else if (typeof e === 'string' && e[0] === '$' && e.slice(1) !== 'r0') {
+      refs.add(e.slice(1))
+    }
+  }
+  walk(exp)
+  const list = [...refs]
+
+  let checked = 0
+  let mismatches = 0
+  const rec = (i: number, cur: Context): void => {
+    if (i === list.length) {
+      checked++
+      const o = oop.evaluate(exp, cur)
+      const oo = oop.evaluate(oopSimp, cur)
+      const b = bytecode.evaluate(exp, cur)
+      const bb = bytecode.evaluate(bcSimp, cur)
+      if (!(o === b && o === oo && o === bb)) {
+        mismatches++
+      }
+      return
+    }
+    for (const v of DOMAIN) {
+      cur[list[i]] = v
+      rec(i + 1, cur)
+    }
+  }
+  rec(0, { ...ctx })
+  const msg =
+    `${checked} completions checked; ` +
+    `${mismatches} eval-mismatches ` +
+    `(bytecode simplify changed behavior at depth ${maxDepth})`
+  assert.strictEqual(mismatches, 0, msg)
+}
+
+for (let depth = 2; depth <= 3; depth++) {
+  test(`simplify preserves evaluation semantics for deep spiral depth ${depth}`, () => {
+    assertEvalEquivalent(buildSpiral(depth), depth)
+  })
+}

--- a/src/__test__/unit/simplify-or-and-in-eval-equivalence.test.ts
+++ b/src/__test__/unit/simplify-or-and-in-eval-equivalence.test.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+
+import type { ContextValue } from '../../common/evaluable.js'
+import Engine, { type Context, type ExpressionInput } from '../../index.js'
+
+/**
+ * Behavioural (evaluation-equivalence) property tests for the bytecode
+ * `simplify` of OR(AND(ref1, ref2), …) style conditions.
+ *
+ * The canonical structural-fidelity regressions for these patterns live in the
+ * data-driven suite as conditions `249-and-or-eqs.json`, `250-or-and-in.json`
+ * and `251-or-and-in-mixed-eq-in.json` (they assert exact expected output for
+ * both evaluators). The bug those guard against — an operand being dropped or
+ * mis-merged during simplify — is a *behavioural* regression, so this suite
+ * additionally verifies the stronger property that `simplify` never changes the
+ * evaluated truth table: for every context completion, the original expression,
+ * the OOP-simplified form and the bytecode-simplified form must all agree.
+ *
+ * This catches a simplify that is structurally odd but behaviourally wrong, or
+ * one that silently drops an operand (changing the result), even when it does
+ * not match one of the hardcoded expected shapes.
+ */
+
+interface Case {
+  description: string
+  expression: ExpressionInput
+}
+
+const CASES: Case[] = [
+  {
+    description:
+      'two branches sharing ref1 value (the classic drop/merge scenario)',
+    expression: [
+      'OR',
+      ['AND', ['==', '$a', 1], ['==', '$b', 3]],
+      ['AND', ['==', '$a', 1], ['==', '$b', 4]],
+    ],
+  },
+  {
+    description: 'nested AND wrapping the OR (Loss1PropertyRestored shape)',
+    expression: [
+      'AND',
+      ['AND', ['==', '$LossHasAny', 'yes'], ['==', '$Loss1Type', 'property']],
+      [
+        'OR',
+        [
+          'AND',
+          ['==', '$Loss1Type', 'property'],
+          ['==', '$Loss1ClaimStatus', 'closed'],
+        ],
+        [
+          'AND',
+          ['==', '$Loss1Type', 'property'],
+          ['==', '$Loss1ClaimStatus', 'declined'],
+        ],
+      ],
+    ],
+  },
+  {
+    description: 'distinct ref1 values keep both OR branches',
+    expression: [
+      'OR',
+      ['AND', ['==', '$a', 1], ['==', '$b', 3]],
+      ['AND', ['==', '$a', 2], ['==', '$b', 4]],
+    ],
+  },
+  {
+    description: 'mixed == and IN ref2 operators',
+    expression: [
+      'OR',
+      [
+        'AND',
+        ['==', '$Loss1Type', 'property'],
+        ['==', '$Loss1ClaimStatus', 'closed'],
+      ],
+      [
+        'AND',
+        ['IN', '$Loss1Type', ['property', 'home']],
+        ['==', '$Loss1ClaimStatus', 'declined'],
+      ],
+    ],
+  },
+  {
+    description: 'three-way OR sharing ref1 with a merged IN set',
+    expression: [
+      'OR',
+      ['AND', ['IN', '$a', [1, 2]], ['==', '$b', 'x']],
+      ['AND', ['IN', '$a', [1, 2]], ['==', '$b', 'y']],
+      ['AND', ['IN', '$a', [1, 2]], ['==', '$b', 'z']],
+    ],
+  },
+]
+
+const oop = new Engine({ evaluator: 'oop' })
+const bytecode = new Engine({ evaluator: 'bytecode' })
+
+// Collect the (unique) top-level ref keys referenced by an expression.
+function collectRefs(exp: unknown, acc: string[] = []): string[] {
+  if (Array.isArray(exp)) {
+    for (const item of exp) {
+      collectRefs(item, acc)
+    }
+    return acc
+  }
+  if (typeof exp === 'string' && exp.startsWith('$')) {
+    const key = exp.slice(1)
+    if (!acc.includes(key)) {
+      acc.push(key)
+    }
+  }
+  return acc
+}
+
+// A representative value domain for the truth table (undefined => "absent").
+const DOMAIN: ContextValue[] = [
+  undefined,
+  null,
+  'yes',
+  'no',
+  'property',
+  'closed',
+  'declined',
+  'home',
+  'x',
+  'y',
+  'z',
+  1,
+  2,
+  3,
+]
+
+function assertEvalEquivalent(exp: ExpressionInput): void {
+  const refs = collectRefs(exp)
+  let contexts = 0
+  let mismatches = 0
+
+  // The simplified forms depend only on the expression (and fixed context),
+  // so compute them once and re-evaluate across every context completion.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const oopSimp = oop.simplify(exp, {}) as ExpressionInput
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const bcSimp = bytecode.simplify(exp, {}) as ExpressionInput
+
+  const visit = (depth: number, cur: Context): void => {
+    if (depth === refs.length) {
+      contexts++
+      const oopExp = oop.evaluate(exp, cur)
+      const bcExp = bytecode.evaluate(exp, cur)
+      const oopSimpVal = oop.evaluate(oopSimp, cur)
+      const bcSimpVal = bytecode.evaluate(bcSimp, cur)
+      // The original and both simplifications must agree on every completion.
+      if (
+        !(oopExp === bcExp && oopExp === oopSimpVal && oopExp === bcSimpVal)
+      ) {
+        mismatches++
+        if (mismatches <= 5) {
+          console.log(
+            '  eval-mismatch @',
+            JSON.stringify(cur),
+            'exp_oop',
+            oopExp,
+            'exp_bc',
+            bcExp,
+            'simp_oop',
+            oopSimpVal,
+            'simp_bc',
+            bcSimpVal
+          )
+        }
+      }
+      return
+    }
+    for (const v of DOMAIN) {
+      cur[refs[depth]] = v
+      visit(depth + 1, cur)
+    }
+  }
+
+  visit(0, {})
+  assert.strictEqual(
+    mismatches,
+    0,
+    `${contexts} contexts evaluated; ${mismatches} eval-mismatches for ${JSON.stringify(
+      exp
+    )}`
+  )
+}
+
+for (const tc of CASES) {
+  test(`eval-equivalence: ${tc.description}`, () => {
+    assertEvalEquivalent(tc.expression)
+  })
+}

--- a/src/bytecode/compiler.ts
+++ b/src/bytecode/compiler.ts
@@ -163,6 +163,14 @@ export interface CompilerState {
   // Side tables for the simplify interpreter
   overlapRefsEntries: Array<{ pos: number; refIdxs: number[] }>
   directionEntries: Array<{ pos: number; dir: 0 | 1 }>
+  // When true, the compiler preserves the original nested structure for the
+  // simplify interpreter instead of applying the OR(AND(ref1, ref2), …)
+  // OR_AND_IN merge optimization. That optimization collapses branches that
+  // share ref1's value into a single merged ref2 set, which is lossy for
+  // structural reconstruction — simplify must be able to reproduce the input
+  // verbatim, so it skips the merge and lets the short-circuit path preserve
+  // each branch. evaluate() keeps the optimization for its performance gain.
+  simplify: boolean
 }
 
 function isStaticCollection(raw: Input, opts: Options): raw is ArrayInput {
@@ -526,7 +534,9 @@ function emitExpression(raw: Input, state: CompilerState): void {
   }
 
   if (operator === maps.orOp) {
-    const orAnd2 = detectOrAndIn2Pattern(arr, state)
+    // Skip the merge when compiling for simplify so the nested structure can
+    // be reconstructed verbatim (the merge collapses branches by ref1 value).
+    const orAnd2 = state.simplify ? null : detectOrAndIn2Pattern(arr, state)
     if (orAnd2 !== null) {
       const { ref1Raw, ref2Raw, entries, entryOperators } = orAnd2
       const { bytecode } = state
@@ -817,7 +827,8 @@ export interface CompiledExpression {
  */
 export function compile(
   raw: ExpressionInput,
-  opts: Options
+  opts: Options,
+  simplify = false
 ): CompiledExpression {
   const maps = buildOperatorMaps(opts)
   const state: CompilerState = {
@@ -834,6 +845,7 @@ export function compile(
     constIndex: new Map(),
     overlapRefsEntries: [],
     directionEntries: [],
+    simplify,
   }
   emitExpression(raw, state)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,12 @@ class Engine {
   private readonly evaluator: 'oop' | 'bytecode'
   private readonly bytecodeCache: WeakMap<ExpressionInput, CompiledExpression> =
     new WeakMap()
+  // Separate cache for the simplify compiler output. Simplify must preserve the
+  // nested structure verbatim, so it compiles with the OR_AND_IN merge disabled
+  // (see `compile`'s `simplify` flag), which yields different bytecode than the
+  // evaluate path and therefore cannot share `bytecodeCache`.
+  private readonly simplifyCache: WeakMap<ExpressionInput, CompiledExpression> =
+    new WeakMap()
 
   /**
    * @constructor
@@ -90,6 +96,20 @@ class Engine {
       this.parser.parse(exp) // validates root operator and expression structure
       compiled = compile(exp, this.parser.options)
       this.bytecodeCache.set(exp, compiled)
+    }
+    return compiled
+  }
+
+  /**
+   * Compile for simplify: preserves the original nested structure so the
+   * simplify interpreter can reproduce the input verbatim (no OR_AND_IN merge).
+   */
+  private getSimplifiedCompiled(exp: ExpressionInput): CompiledExpression {
+    let compiled = this.simplifyCache.get(exp)
+    if (compiled === undefined) {
+      this.parser.parse(exp) // validates root operator and expression structure
+      compiled = compile(exp, this.parser.options, true)
+      this.simplifyCache.set(exp, compiled)
     }
     return compiled
   }
@@ -157,7 +177,7 @@ class Engine {
   ): Input | boolean {
     if (this.evaluator === 'bytecode') {
       return interpretSimplify(
-        this.getCompiled(exp),
+        this.getSimplifiedCompiled(exp),
         context,
         strictKeys,
         optionalKeys

--- a/types/bytecode/compiler.d.ts
+++ b/types/bytecode/compiler.d.ts
@@ -45,6 +45,7 @@ export interface CompilerState {
         pos: number;
         dir: 0 | 1;
     }>;
+    simplify: boolean;
 }
 /**
  * Check whether an OR expression matches the pattern:
@@ -82,5 +83,5 @@ export interface CompiledExpression {
  * Compile a raw ExpressionInput into bytecode.
  * The result should be cached and reused across evaluate() calls.
  */
-export declare function compile(raw: ExpressionInput, opts: Options): CompiledExpression;
+export declare function compile(raw: ExpressionInput, opts: Options, simplify?: boolean): CompiledExpression;
 export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,12 +39,18 @@ declare class Engine {
     private readonly parser;
     private readonly evaluator;
     private readonly bytecodeCache;
+    private readonly simplifyCache;
     /**
      * @constructor
      * @param {Options?} options Parser options.
      */
     constructor(options?: Partial<Options>);
     private getCompiled;
+    /**
+     * Compile for simplify: preserves the original nested structure so the
+     * simplify interpreter can reproduce the input verbatim (no OR_AND_IN merge).
+     */
+    private getSimplifiedCompiled;
     /**
      * Evaluate the expression.
      * @param {ExpressionInput} exp Raw expression.


### PR DESCRIPTION
Bytecode simplify collapsed nested OR/AND structure via the OR_AND_IN merge, which could only reconstruct the flat 2-level case and dropped operands in deeper compositions. For simplify we now skip that merge so the original nested structure is preserved verbatim (evaluate keeps the optimization for performance). Adds regression tests, including arbitrary-depth nesting.
